### PR TITLE
Add template workflow for ROS

### DIFF
--- a/workflow-templates/ros-ci.properties.json
+++ b/workflow-templates/ros-ci.properties.json
@@ -1,0 +1,4 @@
+{
+    "name": "ROS Packages Workflow",
+    "description": "workflow template for ROS packages."
+}

--- a/workflow-templates/ros-ci.yml
+++ b/workflow-templates/ros-ci.yml
@@ -1,0 +1,14 @@
+on:
+  push:
+    branches: [$default-branch]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  linter:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Linter
+    uses: sbgisen/.github/.github/workflows/linter_ros_package.yaml@main
+  release-drafter:
+    name: Release drafter
+    uses: sbgisen/.github/.github/workflows/release-drafter.yml@main


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
ROSパッケージ用のテンプレートを追加
- fix #9 

<!-- 変更の詳細 -->
## Detail
https://github.com/sbgisen/cube で採用しているworkflowをもとに、
ブランチ名を`$default-branch`に修正

<!-- 動作検証を行った項目 -->
## Test
- [x] 同様のテンプレートをTacha-S側で作成し、template workflowとして使えることを確認
- [x] `$default-branch`がそのリポジトリのデフォルトブランチに置き換えられることを確認

