### PR TITLE
Fix the order of lint xml

### DIFF
--- a/.github/workflows/linter_ros_package.yaml
+++ b/.github/workflows/linter_ros_package.yaml
@@ -161,7 +161,7 @@ jobs:
           file_list=${{ needs.changes.outputs.xml_files }}
           files=`echo ${file_list} | xargs -n 1 | grep -E ".*launch/.*\.(launch|xml)" || true`
           if [ -z ${files} ]; then
-            echo "There is not launch files."
+            echo "There are no launch files."
           else
             xmllint --noout --schema roslaunch.xsd ${files} 2>&1 1>/dev/null |\
             reviewdog -name="xmllint" -reporter=github-pr-review -efm='%f:%l:%m' -filter-mode=file -fail-on-error
@@ -174,7 +174,7 @@ jobs:
           wget http://download.ros.org/schema/package_format2.xsd
           files=`echo ${{ needs.changes.outputs.xml_files }} | xargs -n 1 | grep -E ".*package.xml" || true`
           if [ -z ${files} ]; then
-            echo "There is not package.xml files."
+            echo "There are no package.xml files."
           else
             xmllint --noout --schema package_format2.xsd ${files} 2>&1 1>/dev/null |\
             reviewdog -name="xmllint" -reporter=github-pr-review -efm='%f:%l:%m' -filter-mode=file -fail-on-error


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
Lintエラーをログに正常に吐き出すために、XMLの順序をformatterを後に実行するようにした。
- fix #16 
roslaunch, package.xmlのどちらかのファイルがない場合にエラーになってしまっていたバグを修正
- fix #17 

<!-- 変更の詳細 -->
## Detail
- roslaunch, package.xmlのLinterをformatterより先に配置
  - libxml2-utilsのインストール箇所を変更
- roslaunch, package.xmlのどちらかのファイルがない場合にエラーになってしまっていたバグを修正
  - grepが一つもマッチしなくてもerror codeを出さないように`|| true`を追加
  - `files`が空であったらその旨をログに出して正常終了するように修正

<!-- 動作検証を行った項目 -->
## Test
- [x] 同等のworkflowを https://github.com/Tacha-S/.github に作成し正常に動作することを確認。

![Screenshot from 2021-10-13 15-24-12](https://user-images.githubusercontent.com/13605820/137078498-4c43b7c8-bb7a-449c-80be-f9725e3cb1aa.png)

