### PR TITLE
fix: publish release draft when PR merged.

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,5 +8,7 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@fe52e97d262833ae07d05efaf1a239df3f1b5cd4 #v5.15.0
+        with:
+          disable-releaser: ${{ github.ref_name != github.event.repository.default_branch }}
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

  Pull requestがOpenしたときにDraftが生成されたので修正。
## Detail

  * defaultブランチにpushされた時にdraft生成されるように修正

<!-- 動作検証を行った項目 -->
## Test

  * [x] fork先で試した

## refs
<!-- 関連するIssue または pull request -->
 - [PR作成時のActionログ](https://github.com/h-wata/ci-test/runs/4135384436?check_suite_focus=true)を見ると、autolabelerで止まっているのがわかる。
 - [PR merge時のログ](https://github.com/h-wata/ci-test/runs/4135391158?check_suite_focus=true)を見ると、draftが生成されている。
- fix #25 