### PR TITLE
Support setup script

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -20,6 +20,9 @@ on:
         default: ubuntu-latest
         required: false
         type: string
+      setup_script:
+        required: false
+        type: string
 
 jobs:
   build:
@@ -60,6 +63,13 @@ jobs:
           rosdep install -iry --from-paths . --rosdistro ${ROS_DISTRO}
         shell: bash
         working-directory: ${{ github.workspace }}/ros
+      - name: Run setup script
+        run: |
+          if [ "${{ inputs.setup_script }}" != "" ]; then
+            ./${{ inputs.setup_script }}
+          fi
+        shell: bash
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
       - name: Install libfreenect2
         if: inputs.install_libfreenect2
         run: |

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -7,6 +7,9 @@ on:
         default: false
         required: false
         type: boolean
+      setup_script:
+        required: false
+        type: string
 
 jobs:
   test:
@@ -40,6 +43,13 @@ jobs:
           rosdep install -iry --from-paths . --rosdistro ${ROS_DISTRO}
         shell: bash
         working-directory: ${{ github.workspace }}/ros
+      - name: Run setup script
+        run: |
+          if [ "${{ inputs.setup_script }}" != "" ]; then
+            ./${{ inputs.setup_script }}
+          fi
+        shell: bash
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
       - name: Install libfreenect2
         if: inputs.install_libfreenect2
         run: |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ You can call workflow, with the following:
   Default is `ubuntu-latest`.
   To use self hosted runner, set tags to this parameter such as `[self-hosted, lab]`
 
+- inputs.setup_script (Optional)
+
+  Setup script filename.
+  Default is empty.
+  To install/setup dependencies not supported by `wstool` or `rosdep`.
+
 #### Usage
 
 You can call workflow, with the following:
@@ -111,6 +117,12 @@ jobs:
 
   Whether the workflow install libfreenect2.
   Default is `false`.
+
+- inputs.setup_script (Optional)
+
+  Setup script filename.
+  Default is empty.
+  To install/setup dependencies not supported by `wstool` or `rosdep`.
 
 #### Usage
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
wstoolやrosdepでサポートしていない依存のインストール等をCIでも対応

- fix #27 

<!-- 変更の詳細 -->
## Detail
inputsにsetup scriptのファイル名を与えられるようにし、
defaultの空でなければそのファイルを実行するように。

<!-- 動作検証を行った項目 -->
## Test
- [HELLOを出力するsetup_scriptを指定したとき](https://github.com/Tacha-S/cube_apps/runs/4162102013?check_suite_focus=true)
- [defaultのとき](https://github.com/Tacha-S/cube_apps/runs/4162147482?check_suite_focus=true)
