### PR TITLE
Run build and test on push event when linter skipped

### DIFF
--- a/workflow-templates/ros-ci.yml
+++ b/workflow-templates/ros-ci.yml
@@ -11,6 +11,7 @@ jobs:
     uses: sbgisen/.github/.github/workflows/linter_ros_package.yaml@main
   build:
     needs: linter
+    if: ${{ !failure() }}
     name: Build
     uses: sbgisen/.github/.github/workflows/ros-build.yml@main
     secrets:
@@ -18,6 +19,7 @@ jobs:
       known_hosts: ${{ secrets.KNOWN_HOSTS }}
   test:
     needs: linter
+    if: ${{ !failure() }}
     name: Test
     uses: sbgisen/.github/.github/workflows/ros-test.yml@main
   release-drafter:

--- a/workflow-templates/ros-ci.yml
+++ b/workflow-templates/ros-ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build
     uses: sbgisen/.github/.github/workflows/ros-build.yml@main
     secrets:
-      ssh_key: ${{ secrets.SSH_KEY }}
+      ssh_key: ${{ secrets.GISEN_ROBO_GIT }}
       known_hosts: ${{ secrets.KNOWN_HOSTS }}
   test:
     needs: linter


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
Linterがskipされてもpush時にはbuild, testが走るように

- fix #33 

<!-- 変更の詳細 -->
## Detail
ついでに、secretのIDも現状のものに合わせておきました。

## refs
<!-- 関連するIssue または pull request -->
[この修正を導入済みのAction](https://github.com/sbgisen/cube_demos/actions/runs/1452109341)
