### PR TITLE
Pass build and test if repository has no CMakeLists.txt

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -8,6 +8,10 @@ on:
       known_hosts:
         required: true
     inputs:
+      package_name:
+        default: ${{ github.event.repository.name }}
+        required: false
+        type: string
       install_libfreenect2:
         default: false
         required: false
@@ -98,14 +102,14 @@ jobs:
           catkin config --extend /opt/ros/${ROS_DISTRO}
           catkin config --no-blacklist
           catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          catkin build -s --no-status
+          catkin build -s --no-status ${{ inputs.package_name }}
         shell: bash
         working-directory: ${{ github.workspace }}/ros
       - name: Run test
         if: inputs.run_test
         run: |
           source devel/setup.bash
-          catkin run_tests -i --no-deps --no-status ${{ github.event.repository.name }}
+          catkin run_tests -i --no-deps --no-status ${{ inputs.package_name }}
           catkin_test_results --verbose --all build || (trap - ERR && exit 1)
         shell: bash
         working-directory: ${{ github.workspace }}/ros

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -95,6 +95,9 @@ jobs:
         working-directory: ${{ github.workspace }}
       - name: Build ros packages
         run: |
+          if [ `find src/${{ github.event.repository.name }} -name CMakeLists.txt | wc -l` -eq 0 ]; then
+            exit 0
+          fi
           apt-get install -y python-catkin-tools
           source /opt/ros/${ROS_DISTRO}/setup.bash
           export PATH="/usr/lib/ccache:$PATH"
@@ -108,6 +111,9 @@ jobs:
       - name: Run test
         if: inputs.run_test
         run: |
+          if [ `find src/${{ github.event.repository.name }} -name CMakeLists.txt | wc -l` -eq 0 ]; then
+            exit 0
+          fi
           source devel/setup.bash
           catkin run_tests -i --no-deps --no-status ${{ inputs.package_name }}
           catkin_test_results --verbose --all build || (trap - ERR && exit 1)

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -3,6 +3,10 @@ name: ros-test
 on:
   workflow_call:
     inputs:
+      package_name:
+        default: ${{ github.event.repository.name }}
+        required: false
+        type: string
       install_libfreenect2:
         default: false
         required: false
@@ -73,13 +77,13 @@ jobs:
           catkin config --extend /opt/ros/${ROS_DISTRO}
           catkin config --no-blacklist
           catkin config --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          catkin build -s --no-status
+          catkin build -s --no-status ${{ inputs.package_name }}
         shell: bash
         working-directory: ${{ github.workspace }}/ros
       - name: Run test
         run: |
           source devel/setup.bash
-          catkin run_tests -i --no-deps --no-status ${{ github.event.repository.name }}
+          catkin run_tests -i --no-deps --no-status ${{ inputs.package_name }}
           catkin_test_results --verbose --all build || (trap - ERR && exit 1)
         shell: bash
         working-directory: ${{ github.workspace }}/ros

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -71,6 +71,9 @@ jobs:
         working-directory: ${{ github.workspace }}
       - name: Build ros packages
         run: |
+          if [ `find src/${{ github.event.repository.name }} -name CMakeLists.txt | wc -l` -eq 0 ]; then
+            exit 0
+          fi
           sudo apt-get install -y python-catkin-tools
           source /opt/ros/${ROS_DISTRO}/setup.bash
           catkin init
@@ -82,6 +85,9 @@ jobs:
         working-directory: ${{ github.workspace }}/ros
       - name: Run test
         run: |
+          if [ `find src/${{ github.event.repository.name }} -name CMakeLists.txt | wc -l` -eq 0 ]; then
+            exit 0
+          fi
           source devel/setup.bash
           catkin run_tests -i --no-deps --no-status ${{ inputs.package_name }}
           catkin_test_results --verbose --all build || (trap - ERR && exit 1)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ You can call workflow, with the following:
   Use to execute `wstool`.
   Set the result of `ssh-keyscan github.com` to secrets on the repository/organization.
 
+- inputs.package_name (Optional)
+
+  ROS package name.
+  Default is `github.event.repository.name`.
+
 - inputs.install_libfreenect2 (Optional)
 
   Whether the workflow install libfreenect2.
@@ -112,6 +117,11 @@ jobs:
 `ros-test.yml` can run ros test.
 
 #### Input parameters
+
+- inputs.package_name (Optional)
+
+  ROS package name.
+  Default is `github.event.repository.name`.
 
 - inputs.install_libfreenect2 (Optional)
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
リポジトリがまだROSパッケージとして成形していないくてもCIがエラーを起こさないように

- fix #35 

<!-- 変更の詳細 -->
## Detail

- `CMakeLists.txt`がリポジトリ配下にない場合にbuild, testをパスするように
- ROSパッケージ名を引数で指定できるように
  - ビルドもworkspace全体から指定したパッケージのみへ

## refs

https://github.com/sbgisen/ros-package-template/runs/4261930904?check_suite_focus=true
