### PR TITLE
Add catkin lint and clang tidy

### DIFF
--- a/.catkin_lint
+++ b/.catkin_lint
@@ -1,0 +1,5 @@
+[catkin_lint]
+quiet = yes
+
+[*]
+uninstalled_script = ignore

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,59 @@
+---
+Checks: "-*,
+  performance-*,
+  llvm-namespace-comment,
+  modernize-redundant-void-arg,
+  modernize-use-nullptr,
+  modernize-use-default,
+  modernize-use-override,
+  modernize-loop-convert,
+  modernize-make-shared,
+  modernize-make-unique,
+  misc-unused-parameters,
+  readability-named-parameter,
+  readability-redundant-smartptr-get,
+  readability-redundant-string-cstr,
+  readability-simplify-boolean-expr,
+  readability-container-size-empty,
+  readability-identifier-naming,
+  "
+HeaderFilterRegex: ""
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key: llvm-namespace-comment.ShortNamespaceLines
+    value: "10"
+  - key: llvm-namespace-comment.SpacesBeforeComments
+    value: "2"
+  - key: misc-unused-parameters.StrictMode
+    value: "1"
+  - key: readability-braces-around-statements.ShortStatementLines
+    value: "2"
+  # type names
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.UnionCase
+    value: CamelCase
+  # method names
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  # variable names
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.GlobalVariablePrefix
+    value: "g_"
+  - key: readability-identifier-naming.MemberSuffix
+    value: "_"
+  # const static or global variables are UPPER_CASE
+  - key: readability-identifier-naming.EnumConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.StaticConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.ClassConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: UPPER_CASE
+  # namespace
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -138,7 +138,8 @@ jobs:
           sed -i -e ':a;N;$!ba;s/\]\n*\[/,/g' ../../build/compile_commands.json
           compdb -p ../../build list > ../../compile_commands.json
           echo "------------------------ Run Clang-tidy ------------------------"
-          result=`clang-tidy-13 --quiet ${{ steps.changes.outputs.cpp_files }}`
+          result=`clang-tidy-13 --quiet ${{ steps.changes.outputs.cpp_files }} \
+          --header-filter="${{ github.workspace }}/ros/src/${{ github.event.repository.name }}/include/.*"`
           if [[ -z ${result} ]]; then
             exit 0
           fi

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -137,6 +137,7 @@ jobs:
           cat ../../build/*/compile_commands.json > ../../build/compile_commands.json
           sed -i -e ':a;N;$!ba;s/\]\n*\[/,/g' ../../build/compile_commands.json
           compdb -p ../../build list > ../../compile_commands.json
+          echo "------------------------ Run Clang-tidy ------------------------"
           result=`clang-tidy-13 --quiet ${{ steps.changes.outputs.cpp_files }}`
           if [[ -z ${result} ]]; then
             exit 0

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -120,3 +120,28 @@ jobs:
           catkin_lint
         shell: bash
         working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
+      - name: Download clang tidy config
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.clang-tidy -O .clang-tidy
+        working-directory: ${{ github.workspace }}/ros
+      - name: clang-tidy
+        if: steps.changes.outputs.cpp == 'true'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+          sudo add-apt-repository -y \
+          "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-13 main"
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy-13
+          pip3 install compdb
+          cat ../../build/*/compile_commands.json > ../../build/compile_commands.json
+          sed -i -e ':a;N;$!ba;s/\]\n*\[/,/g' ../../build/compile_commands.json
+          compdb -p ../../build list > ../../compile_commands.json
+          result=`clang-tidy-13 --quiet ${{ steps.changes.outputs.cpp_files }}`
+          if [[ -z ${result} ]]; then
+            exit 0
+          fi
+          echo ${result}
+          exit 1
+        shell: bash
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -83,3 +83,40 @@ jobs:
           catkin_test_results --verbose --all build || (trap - ERR && exit 1)
         shell: bash
         working-directory: ${{ github.workspace }}/ros
+
+  lint_after_build:
+    name: Lint after build
+    runs-on: [self-hosted, lab]
+    needs: test
+    env:
+      ROS_DISTRO: melodic
+    steps:
+      - name: changed-file-filter
+        id: changes
+        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 #v2.10.2
+        with:
+          filters: |
+            cpp:
+              - '**.h'
+              - '**.hpp'
+              - '**.hh'
+              - '**.hxx'
+              - '**.c'
+              - '**.cpp'
+              - '**.cc'
+              - '**.cxx'
+          list-files: "shell"
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
+      - name: Download catkin lint config
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.catkin_lint -O .catkin_lint
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
+      - name: catkin lint
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          pip3 install catkin_lint
+          source ../../devel/setup.bash
+          catkin_lint
+        shell: bash
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
catkin lintとclang tidyをLinterに追加

- fix #28 

<!-- 変更の詳細 -->
## Detail
clang-tidyの設定はmoveitから引用
どちらもビルド後でないと動作しないためself hosted runnerでテスト動作後に実施するように
reviewdogはerrorformatに複数行のパターンを設定する方法が[不明](https://github.com/reviewdog/reviewdog/issues/1030)なため未導入

## refs

こちらで動作確認実施済み
https://github.com/sbgisen/colorize_pcl/pull/4