### PR TITLE
fix: use vcstool instead of wstool

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -48,14 +48,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ros/src/${{ github.event.repository.name }}
-      - name: Download repositories managed by wstool
+      - name: Download repositories managed by vcstool
         run: |
-          wstool init .
+          if !(type vcs > /dev/null 2>&1); then
+              apt update && apt install -y python3-vcstool
+          fi
           files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall"`
           while [ `echo ${files} | wc -w` -gt 0 ]
           do
-            echo ${files} | xargs -n1 wstool merge -y -t .
-            wstool up -t . -j4 -v
+            echo ${files} | xargs -n1 vcs import --recursive --debug --input
             rm ${files}
             files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall"`
           done

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -26,16 +26,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ros/src/${{ github.event.repository.name }}
-      - name: Download repositories managed by wstool
+      - name: Download repositories managed by vcstool
         run: |
-          if [ ! -e .rosinstall ]; then
-            wstool init .
+          if !(type vcs > /dev/null 2>&1); then
+              sudo apt update && sudo apt install -y python3-vcstool
           fi
           files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall"`
           while [ `echo ${files} | wc -w` -gt 0 ]
           do
-            echo ${files} | xargs -n1 wstool merge -y -t .
-            wstool up -t . -j4 -v
+            echo ${files} | xargs -n1 vcs import --recursive --debug --input
             rm ${files}
             files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall"`
           done


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
  
wstoolではrecursiveなGit cloneに対応していないのでvcstoolを利用した。
<!-- 変更の詳細 -->
## Detail
現状そんなに多くないが依存パッケージで`recursive`のCloneを実施することも増えてくることが予見されるため、recursive optionがあるvcstoolに変更した。


<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- 動作検証を行った項目 -->
## Test
  * [x] [fork](https://github.com/h-wata/outdoor_navigation_tools/runs/4471317661?check_suite_focus=true)先での動作確認
  ※ ros-testの方で失敗しているのはautowareのパッケージでOpencvのVersion固定を行っておらず、Version不一致が起きているため。vcstoolの部分は成功している。

## refs
<!-- 関連するIssue または pull request -->
* fix #30 
## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
