### PR TITLE
Run lint_after_build only when the target event is a PR

### DIFF
--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -95,6 +95,7 @@ jobs:
 
   lint_after_build:
     name: Lint after build
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: [self-hosted, lab]
     needs: test
     env:


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

#44 の修正
`lint_after_build` をPRに対してのみ実行するように変更

## refs

fixes #44 
