### PR TITLE
yamllintの設定アップデート

### DIFF
--- a/.github/workflows/linter_ros_package.yaml
+++ b/.github/workflows/linter_ros_package.yaml
@@ -171,7 +171,7 @@ jobs:
           reporter: github-pr-review
           filter_mode: file
           fail_on_error: true
-          yamllint_flags: -c .yamllint ${{ needs.changes.outputs.yaml_files }}
+          yamllint_flags: -s -c .yamllint ${{ needs.changes.outputs.yaml_files }}
   xml:
     name: runner / xml
     runs-on: ubuntu-18.04

--- a/.yamllint
+++ b/.yamllint
@@ -14,3 +14,5 @@ rules:
   quoted-strings:
     quote-type: double
     required: false
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

yamllintで警告のみの場合でもCIが止まるように
yamlファイルのコメントとコンテンツの間に必要な最小スペースを2->1に変更

- fix #59 
