### PR TITLE
Run apt update before installing depends

### DIFF
--- a/.github/workflows/linter_ros_package.yaml
+++ b/.github/workflows/linter_ros_package.yaml
@@ -193,6 +193,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
+          sudo apt update
           sudo apt install libxml2-utils
           wget https://gist.githubusercontent.com/nalt/dfa2abc9d2e3ae4feb82ca5608090387/raw/roslaunch.xsd
           file_list="${{ needs.changes.outputs.xml_files }}"
@@ -218,7 +219,6 @@ jobs:
           fi
       - name: xmllint format
         run: |
-          sudo apt install libxml2-utils
           echo ${{ needs.changes.outputs.xml_files }} |\
           xargs -n 1 | xargs -I {} bash -c "xmllint --format {} |\
           diff -B {} - |\

--- a/.github/workflows/linter_ros_package.yaml
+++ b/.github/workflows/linter_ros_package.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
       - name: changed-file-filter
         id: changes
-        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 #v2.10.2
+        uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
         with:
           filters: |
             cpp:
@@ -136,7 +136,8 @@ jobs:
           flake8 --version
           file_list="${{ needs.changes.outputs.python_files }}"
           flake8 --select=D ${file_list} |\
-          reviewdog -name="docstring" -level warning -reporter=github-pr-check -efm='%f:%l:%c: %.%n %m' -filter-mode=file
+          reviewdog -name="docstring" -level warning -reporter=github-pr-check \
+          -efm='%f:%l:%c: %.%n %m' -filter-mode=file
 
   cmake:
     name: runner / cmake-format


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

linterのworkflowで依存パッケージをインストールする前にapt updateを実行することで、
パッケージが見つからない問題の解消

- fix #70 

<!-- 変更の詳細 -->
## Detail

- yamllintの対応
- apt updateの追加

<!-- 動作検証を行った項目 -->
## Test

https://github.com/sbgisen/cube_python_api/runs/5597830475?check_suite_focus=true

