### PR TITLE
Add option for ignore rosinstall path

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -27,6 +27,12 @@ on:
       setup_script:
         required: false
         type: string
+      ignore_rosinstalls:
+        default: ""
+        required: false
+        type: string
+        description: "Specify relative paths from /path/to/workspace/src as in
+          ./ros-package/.rosinstall, separated by commas."
       ros_distro:
         default: melodic
         required: false
@@ -61,12 +67,27 @@ jobs:
           if !(type vcs > /dev/null 2>&1); then
               apt update && apt install -y python3-vcstool git
           fi
-          files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall"`
-          while [ `echo ${files} | wc -w` -gt 0 ]
+
+          not_contains() {
+              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && exit 1 || exit 0
+          }
+
+          IFS=', ' read -ra ignore_files <<< "${{ inputs.ignore_rosinstalls }}"
+          files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall" | sort`
+          pre_n=0
+          n=`echo ${files} | wc -w`
+          while [ `comm -3 <(echo ${files}) <(echo ${ignore_files[@]} | sort) | wc -w` -ne 0 -a ${n} -ne ${pre_n} ]
           do
-            echo ${files} | xargs -n1 vcs import --recursive --debug --input
-            rm ${files}
-            files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall"`
+              for f in ${files}
+              do
+                  if `not_contains ${f} ${ignore_files}`; then
+                      vcs import --recursive --debug < ${f}
+                      ignore_files+=(${f})
+                  fi
+              done
+              files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall" | sort`
+              pre_n=${n}
+              n=`echo ${files} | wc -w`
           done
         shell: bash
         working-directory: ${{ github.workspace }}/ros/src
@@ -94,7 +115,8 @@ jobs:
       - name: Install libfreenect2
         if: inputs.install_libfreenect2
         run: |
-          apt-get install -y build-essential cmake pkg-config libusb-1.0-0-dev libturbojpeg0-dev libglfw3-dev checkinstall
+          apt-get install -y build-essential cmake pkg-config libusb-1.0-0-dev \
+                             libturbojpeg0-dev libglfw3-dev checkinstall
           if dpkg -l libfreenect2; then
             echo "Already installed"
           else

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -14,6 +14,12 @@ on:
       setup_script:
         required: false
         type: string
+      ignore_rosinstalls:
+        default: ""
+        required: false
+        type: string
+        description: "Specify relative paths from /path/to/workspace/src as in
+          ./ros-package/.rosinstall, separated by commas."
 
 jobs:
   test:
@@ -33,12 +39,27 @@ jobs:
           if !(type vcs > /dev/null 2>&1); then
               sudo apt update && sudo apt install -y python3-vcstool
           fi
-          files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall"`
-          while [ `echo ${files} | wc -w` -gt 0 ]
+
+          not_contains() {
+              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && exit 1 || exit 0
+          }
+
+          IFS=', ' read -ra ignore_files <<< "${{ inputs.ignore_rosinstalls }}"
+          files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall" | sort`
+          pre_n=0
+          n=`echo ${files} | wc -w`
+          while [ `comm -3 <(echo ${files}) <(echo ${ignore_files[@]} | sort) | wc -w` -ne 0 -a ${n} -ne ${pre_n} ]
           do
-            echo ${files} | xargs -n1 vcs import --recursive --debug --input
-            rm ${files}
-            files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall"`
+              for f in ${files}
+              do
+                  if `not_contains ${f} ${ignore_files}`; then
+                      vcs import --recursive --debug < ${f}
+                      ignore_files+=(${f})
+                  fi
+              done
+              files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall" | sort`
+              pre_n=${n}
+              n=`echo ${files} | wc -w`
           done
         shell: bash
         working-directory: ${{ github.workspace }}/ros/src

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ You can call workflow, with the following:
   Specify relative paths from `/path/to/workspace/src` as in `./ros-package/.rosinstall`, separated by commas.
   Default is empty.
 
+- inputs.ros_distro (Optional)
+
+  Specify ROS distribution.
+  Default is `melodic`.
+
 #### Usage
 
 You can call workflow, with the following:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ You can call workflow, with the following:
   Default is empty.
   To install/setup dependencies not supported by `wstool` or `rosdep`.
 
+- inputs.ignore_rosinstalls (Optional)
+
+  Specify relative paths from `/path/to/workspace/src` as in `./ros-package/.rosinstall`, separated by commas.
+  Default is empty.
+
 #### Usage
 
 You can call workflow, with the following:
@@ -133,6 +138,11 @@ jobs:
   Setup script filename.
   Default is empty.
   To install/setup dependencies not supported by `wstool` or `rosdep`.
+
+- inputs.ignore_rosinstalls (Optional)
+
+  Specify relative paths from `/path/to/workspace/src` as in `./ros-package/.rosinstall`, separated by commas.
+  Default is empty.
 
 #### Usage
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

指定したrosinstallを無視するoptionを追加

- fix #66 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- 動作検証を行った項目 -->
## Test
  * [x] [cube_python_api](https://github.com/sbgisen/cube_python_api/pull/132)で動作検証した

## refs
<!-- 関連するIssue または pull request -->
## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
@MikhailBertrand のレビュー必須でお願いします。
