### PR TITLE
add steps to build and publish documentations

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -37,6 +37,11 @@ on:
         default: melodic
         required: false
         type: string
+      doc_module_path:
+        default: src/${{ github.event.repository.name }}
+        required: false
+        type: string
+        description: "Specify module path for sphinx-apidoc."
 
 jobs:
   build:
@@ -161,3 +166,26 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/ros
         timeout-minutes: 30
+      - name: Install sphinx dependencies
+        run: |
+          if [ `find . -wholename ./docs/_sources/conf.py | wc -l` -eq 0 ]; then
+            exit 0
+          fi
+          apt-get install -y python-pip
+          pip2 install sphinx==1.8.6
+          pip2 install bs4
+          if [ `find . -wholename ./docs/_sources/requirements.txt | wc -l` -eq 1 ]; then
+            pip2 install -r docs/_sources/requirements.txt
+          fi
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
+      - name: Generate documentations
+        id: generate_documents
+        run: |
+          if [ `find . -wholename ./docs/_sources/conf.py | wc -l` -eq 0 ]; then
+            exit 0
+          fi
+          source ../../devel/setup.bash
+          sphinx-apidoc -f -e -o docs/_sources ${{ inputs.doc_module_path }}
+          sphinx-build docs/_sources docs/
+        shell: bash -leo pipefail {0}
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -183,7 +183,7 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
       - name: Publish documentations
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
         if: steps.generate_documents.outputs.file_exists == 1 && github.event.repository.default_branch == github.ref_name
         with:
           publish_branch: gh-pages

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -37,11 +37,6 @@ on:
         default: melodic
         required: false
         type: string
-      doc_module_path:
-        default: src/${{ github.event.repository.name }}
-        required: false
-        type: string
-        description: "Specify module path for sphinx-apidoc."
 
 jobs:
   build:
@@ -169,17 +164,16 @@ jobs:
       - name: Generate documentations
         id: generate_documents
         run: |
-          if [ `find . -wholename ./docs/_sources/conf.py | wc -l` -eq 0 ]; then
+          if [ -f "./docs/_sources/conf.py" ]; then
             exit 0
           fi
           apt-get install -y python-pip
           pip2 install sphinx==1.8.6
-          pip2 install bs4
-          if [ `find . -wholename ./docs/_sources/requirements.txt | wc -l` -eq 1 ]; then
+          if [ -f "./docs/_sources/requirements.txt" ]; then
             pip2 install -r docs/_sources/requirements.txt
           fi
           source ../../devel/setup.bash
-          sphinx-apidoc -f -e -o docs/_sources ${{ inputs.doc_module_path }}
+          sphinx-apidoc -f -e -o docs/_sources src/${{ github.event.repository.name }}
           sphinx-build docs/_sources docs/
           echo "::set-output name=file_exists::$(find . -wholename ./docs/py-modindex.html | wc -l)"
         shell: bash
@@ -191,4 +185,3 @@ jobs:
           publish_branch: gh-pages
           github_token: ${{ github.token }}
           publish_dir: ros/src/${{ github.event.repository.name }}/docs
-          force_orphan: true

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -187,5 +187,14 @@ jobs:
           source ../../devel/setup.bash
           sphinx-apidoc -f -e -o docs/_sources ${{ inputs.doc_module_path }}
           sphinx-build docs/_sources docs/
+          echo "::set-output name=file_exists::$(find . -wholename ./docs/py-modindex.html | wc -l)"
         shell: bash -leo pipefail {0}
         working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
+      - name: Publish documentations
+        uses: peaceiris/actions-gh-pages@v3
+        if: steps.generate_documents.outputs.file_exists == 1 && github.event.repository.default_branch == github.ref_name
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ros/src/${{ github.event.repository.name }}/docs
+          force_orphan: true

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -167,10 +167,14 @@ jobs:
           if [ -f "./docs/_sources/conf.py" ]; then
             exit 0
           fi
-          apt-get install -y python-pip
-          pip2 install sphinx==1.8.6
-          if [ -f "./docs/_sources/requirements.txt" ]; then
-            pip2 install -r docs/_sources/requirements.txt
+          if [ ${ROS_DISTRO} == melodic ]; then
+            apt-get install -y python-pip
+            pip2 install sphinx==1.8.6
+            if [ -f "./docs/_sources/requirements.txt" ]; then
+              pip2 install -r docs/_sources/requirements.txt
+            fi
+          else
+            exit 0
           fi
           source ../../devel/setup.bash
           sphinx-apidoc -f -e -o docs/_sources src/${{ github.event.repository.name }}

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Generate documentations
         id: generate_documents
         run: |
-          if [ -f "./docs/_sources/conf.py" ]; then
+          if [ ! -f "./docs/_sources/conf.py" ]; then
             exit 0
           fi
           if [ ${ROS_DISTRO} == melodic ]; then

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -166,7 +166,8 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/ros
         timeout-minutes: 30
-      - name: Install sphinx dependencies
+      - name: Generate documentations
+        id: generate_documents
         run: |
           if [ `find . -wholename ./docs/_sources/conf.py | wc -l` -eq 0 ]; then
             exit 0
@@ -177,24 +178,17 @@ jobs:
           if [ `find . -wholename ./docs/_sources/requirements.txt | wc -l` -eq 1 ]; then
             pip2 install -r docs/_sources/requirements.txt
           fi
-        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
-      - name: Generate documentations
-        id: generate_documents
-        run: |
-          if [ `find . -wholename ./docs/_sources/conf.py | wc -l` -eq 0 ]; then
-            exit 0
-          fi
           source ../../devel/setup.bash
           sphinx-apidoc -f -e -o docs/_sources ${{ inputs.doc_module_path }}
           sphinx-build docs/_sources docs/
           echo "::set-output name=file_exists::$(find . -wholename ./docs/py-modindex.html | wc -l)"
-        shell: bash -leo pipefail {0}
+        shell: bash
         working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
       - name: Publish documentations
         uses: peaceiris/actions-gh-pages@v3
         if: steps.generate_documents.outputs.file_exists == 1 && github.event.repository.default_branch == github.ref_name
         with:
           publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           publish_dir: ros/src/${{ github.event.repository.name }}/docs
           force_orphan: true


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
* resolves #82 
* 条件を満たすとドキュメントを自動生成するステップを追加
* `gh_pages`のブランチにドキュメントが出てくるだけなので、github pagesなど使いたい場合、手動で設定する必要がある

<!-- 変更の詳細 -->
## Detail
1. レポジトリに`<ROS レポジトリ>/docs/_sources/conf.py`ファイルが存在したらドキュメントを生成するステップを実行
   1. sphinxの依存関係をインストール
       * `docs/_sources/requirements.txt`で追加パッケージをインストール可能 (例：sphinxのテーマなど)
   2. google/numpy style docstring -> RestructredText に変換 (sphinx-apidocを実行)
       * `doc_module_path`オプションでモジュールパスを指摘可能
   4. ドキュメントをビルドする
5. デフォルトブランチにプッシュした後に、生成したドキュメントを、`gh_pages`ブランチにプッシュするステップを実行

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- 動作検証を行った項目 -->
## Test
  * [ ] catkin buildを通った
  * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した

## refs
<!-- 関連するIssue または pull request -->
## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
