### PR TITLE
Run test workflow on docker on self hosted server

### DIFF
--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -20,14 +20,18 @@ on:
         type: string
         description: "Specify relative paths from /path/to/workspace/src as in
           ./ros-package/.rosinstall, separated by commas."
+      ros_distro:
+        default: melodic
+        required: false
+        type: string
 
 jobs:
   test:
     name: Run test
-    runs-on: [self-hosted, lab]
+    runs-on: [self-hosted, docker, "${{ inputs.ros_distro }}"]
     timeout-minutes: 90
     env:
-      ROS_DISTRO: melodic
+      ROS_DISTRO: ${{ inputs.ros_distro }}
     steps:
       - name: Check out source repository
         uses: actions/checkout@v2
@@ -104,7 +108,11 @@ jobs:
           if [ `find src/${{ github.event.repository.name }} -name CMakeLists.txt | wc -l` -eq 0 ]; then
             exit 0
           fi
-          sudo apt-get install -y python-catkin-tools
+          if [ ${ROS_DISTRO} == melodic ]; then
+            apt-get install -y python-catkin-tools
+          else
+            apt-get install -y python3-catkin-tools
+          fi
           source /opt/ros/${ROS_DISTRO}/setup.bash
           catkin init
           catkin config --extend /opt/ros/${ROS_DISTRO}
@@ -120,7 +128,7 @@ jobs:
             exit 0
           fi
           source devel/setup.bash
-          catkin run_tests -i --no-deps --no-status ${{ inputs.package_name }}
+          catkin build --verbose --catkin-make-args run_tests -- -i --no-deps --no-status ${{ inputs.package_name }}
           catkin_test_results --verbose --all build || (trap - ERR && exit 1)
         shell: bash -leo pipefail {0}
         working-directory: ${{ github.workspace }}/ros


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

self hosted serverの実行環境をdockerに移行
それに伴いmelodicに加え、noeticの実行環境整備

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #64 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

[cubeリポジトリ](https://github.com/sbgisen/cube/runs/6108291683?check_suite_focus=true)でテスト
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
