### PR TITLE
Launch Xvfb in ros-test job

### DIFF
--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -128,7 +128,10 @@ jobs:
           if [ `find src/${{ github.event.repository.name }} -name CMakeLists.txt | wc -l` -eq 0 ]; then
             exit 0
           fi
+          apt-get install -y xvfb
           source devel/setup.bash
+          Xvfb :0 -screen 0 1366x768x24 -ac &
+          export DISPLAY=:0
           catkin build --verbose --catkin-make-args run_tests -- -i --no-deps --no-status ${{ inputs.package_name }}
           catkin_test_results --verbose --all build || (trap - ERR && exit 1)
         shell: bash -leo pipefail {0}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
headlessサーバーでGazeboのCamera sensorから正しくTopicを出力するため、xvfbを立ち上げてからTestを行う。


<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #101 

<!-- 変更の詳細 -->
## Detail
https://github.com/sbgisen/ar_docking/pull/65　
にて、ar_dockingのTestが通らなかったための対応。
原因はcamera sensorのTopicが出力されていなかったためar_track_alvarがAR markerのTFを出力出来ていなかったため。
xvfbによって仮想Displayを出力するようにしたら、問題なくTestを通過したことを確認した。

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
 
-->
  * [x] ar_dockingでCIテスト通過検証した 
## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
