### PR TITLE
sphinxのアップロード先と条件の変更

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -7,6 +7,10 @@ on:
         required: true
       known_hosts:
         required: true
+      cube_docs_aws_access_key_id:
+        required: false
+      cube_docs_aws_secret_access_key:
+        required: false
     inputs:
       package_name:
         default: ${{ github.event.repository.name }}
@@ -186,14 +190,22 @@ jobs:
           fi
           source ../../devel/setup.bash
           sphinx-apidoc -f -e -o docs/_sources src/${{ github.event.repository.name }}
-          sphinx-build docs/_sources docs/
-          echo "::set-output name=file_exists::$(find . -wholename ./docs/py-modindex.html | wc -l)"
+          sphinx-build docs/_sources/ docs/_build/
+          echo "::set-output name=file_exists::$(find . -wholename ./docs/_build/py-modindex.html | wc -l)"
         shell: bash
         working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
-      - name: Publish documentations
-        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
-        if: steps.generate_documents.outputs.file_exists == 1 && github.event.repository.default_branch == github.ref_name
+      - name: Publish documentations to AWS S3
+        if: >-
+          steps.generate_documents.outputs.file_exists == 1 &&
+          github.event.repository.default_branch == github.ref_name &&
+          github.event_name == 'push'
+        uses: jakejarvis/s3-sync-action@7ed8b112447abb09f1da74f3466e4194fc7a6311
         with:
-          publish_branch: gh-pages
-          github_token: ${{ github.token }}
-          publish_dir: ros/src/${{ github.event.repository.name }}/docs
+          args: --delete
+        env:
+          AWS_S3_BUCKET: docs.cuboid.cloud
+          DEST_DIR: ${{ github.event.repository.name }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.cube_docs_aws_access_key_id }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.cube_docs_aws_secret_access_key }}
+          AWS_REGION: ap-northeast-1
+          SOURCE_DIR: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}/docs/_build/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ You can call workflow, with the following:
   Use to execute `wstool`.
   Set the result of `ssh-keyscan github.com` to secrets on the repository/organization.
 
+- secrets.cube_docs_aws_access_key_id (Optional)
+
+  Use to publish documentations.
+  Set AWS Access Key ID to secrets on the repository/organization.
+
+- secrets.cube_docs_aws_secret_access_key (Optional)
+
+  Use to publish documentations.
+  Set AWS Secret Access Key to secrets on the repository/organization.
+
 - inputs.package_name (Optional)
 
   ROS package name.


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
- sphinxのドキュメントについて、gh-pagesブランチへのpushではなく、AWSのS3にアップロードするように変更しました
- 条件を以下のように変更しています。
  - ドキュメントのビルド→./docs/_sources/conf.pyの存在（従来通り）
  - ドキュメントのアップロード→デフォルトブランチへのpush＆ビルドの成功
- secrets(任意)が増えているため、本pull requestのmergeの後、 以下のmergeも必要です。<br>https://github.com/sbgisen/cube_python_api/pull/197
- fix #99

<!-- どのような動作検証を行ったか -->
## Test
- cube_python_api内のワークフローを、実行条件を開発ブランチのpushにして実行
  - テストのため、デフォルトブランチでなくても実行できるように.github/workflow/ros-build.ymlの`Install AWS CLI`について、条件`github.event.repository.default_branch == github.ref_name &&`をコメントアウト→[結果](https://github.com/sbgisen/cube_python_api/runs/6913830908?check_suite_focus=true)
  - 上記の部分のコメントアウトは外し、ビルドまでで止まることを確認→[結果](https://github.com/sbgisen/cube_python_api/runs/6915199568?check_suite_focus=true)

## Attention

s3のアップロード先フォルダはリポジトリ名としていますが、docs.cuboid.cloudに公開するには、別途AWS側の設定が必要になります。
（cube_python_api以外で利用した際に上書きを防ぐため、フォルダが別れるようにしています）