### PR TITLE
Add concurrency

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -34,6 +34,10 @@ on:
         description: "Specify relative paths from /path/to/workspace/src as in
           ./ros-package/.rosinstall, separated by commas."
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-build
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -21,6 +21,10 @@ on:
         description: "Specify relative paths from /path/to/workspace/src as in
           ./ros-package/.rosinstall, separated by commas."
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-test
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run test

--- a/.github/workflows/ros2-build.yml
+++ b/.github/workflows/ros2-build.yml
@@ -30,6 +30,10 @@ on:
         description: "Specify relative paths from /path/to/workspace/src as in
           ./ros-package/.rosinstall, separated by commas."
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-build
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ros2-test.yml
+++ b/.github/workflows/ros2-test.yml
@@ -17,6 +17,10 @@ on:
         description: "Specify relative paths from /path/to/workspace/src as in
           ./ros-package/.rosinstall, separated by commas."
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-test
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Run test


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

ROSのbuild, testにconcurrency(同時実行を防ぐ機能)を追加
PR等でpushを連投し不要に過去のコミットに対してCIを動かし続けるのを防ぐ

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #127 

<!-- 変更の詳細 -->
## Detail

https://github.com/sbgisen/.github/blob/main/workflow-templates/ros-ci.yml に追加する場合、現状CIを動かしているリポジトリにも変更が必要になる上に、古くなったCIへのcancelがstepの切り替わり時に効果がありそうな挙動をするのでstepの粒度が荒すぎて期待した動作をしないので、
時間がかかるであろうROSのbuildとtestにのみ追加

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

以下動作例
https://github.com/sbgisen/test_workflow/actions/runs/3898599571 (先に動いていたCI)
https://github.com/sbgisen/test_workflow/actions/runs/3898600843 (同一PRに更にcommitを追加した際のCI)


## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
