### PR TITLE
Fix bug for ignoring rosinstall

### DIFF
--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -76,11 +76,12 @@ jobs:
               apt update && apt install -y python3-vcstool git
           fi
 
-          not_contains() {
-              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && exit 1 || exit 0
+          contains() {
+              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && true || false
           }
 
-          IFS=', ' read -ra ignore_files <<< "${{ inputs.ignore_rosinstalls }}"
+          ignores="${{ inputs.ignore_rosinstalls }}"
+          ignore_files=${ignores//,/ }
           files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall" | sort`
           pre_n=0
           n=`echo ${files} | wc -w`
@@ -88,7 +89,9 @@ jobs:
           do
               for f in ${files}
               do
-                  if `not_contains ${f} ${ignore_files}`; then
+                  if `contains "${ignore_files}" ${f}` || `contains ${f} ".github/"`; then
+                      echo ignore ${f}
+                  else
                       vcs import --recursive --debug < ${f}
                       ignore_files+=(${f})
                   fi

--- a/.github/workflows/ros-build.yml
+++ b/.github/workflows/ros-build.yml
@@ -89,7 +89,7 @@ jobs:
           do
               for f in ${files}
               do
-                  if `contains "${ignore_files}" ${f}` || `contains ${f} ".github/"`; then
+                  if `contains "${ignore_files}" ${f}` || [[ ${f} =~ ".github/" ]]; then
                       echo ignore ${f}
                   else
                       vcs import --recursive --debug < ${f}

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -63,7 +63,7 @@ jobs:
           do
               for f in ${files}
               do
-                  if `contains "${ignore_files}" ${f}` || `contains ${f} ".github/"`; then
+                  if `contains "${ignore_files}" ${f}` || [[ ${f} =~ ".github/" ]]; then
                       echo ignore ${f}
                   else
                       vcs import --recursive --debug < ${f}

--- a/.github/workflows/ros-test.yml
+++ b/.github/workflows/ros-test.yml
@@ -50,11 +50,12 @@ jobs:
               sudo apt update && sudo apt install -y python3-vcstool
           fi
 
-          not_contains() {
-              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && exit 1 || exit 0
+          contains() {
+              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && true || false
           }
 
-          IFS=', ' read -ra ignore_files <<< "${{ inputs.ignore_rosinstalls }}"
+          ignores="${{ inputs.ignore_rosinstalls }}"
+          ignore_files=${ignores//,/ }
           files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall" | sort`
           pre_n=0
           n=`echo ${files} | wc -w`
@@ -62,7 +63,9 @@ jobs:
           do
               for f in ${files}
               do
-                  if `not_contains ${f} ${ignore_files}`; then
+                  if `contains "${ignore_files}" ${f}` || `contains ${f} ".github/"`; then
+                      echo ignore ${f}
+                  else
                       vcs import --recursive --debug < ${f}
                       ignore_files+=(${f})
                   fi

--- a/.github/workflows/ros2-build.yml
+++ b/.github/workflows/ros2-build.yml
@@ -72,11 +72,12 @@ jobs:
               apt update && apt install -y python3-vcstool git
           fi
 
-          not_contains() {
-              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && exit 1 || exit 0
+          contains() {
+              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && true || false
           }
 
-          IFS=', ' read -ra ignore_files <<< "${{ inputs.ignore_rosinstalls }}"
+          ignores="${{ inputs.ignore_rosinstalls }}"
+          ignore_files=${ignores//,/ }
           files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall" | sort`
           pre_n=0
           n=`echo ${files} | wc -w`
@@ -84,7 +85,9 @@ jobs:
           do
               for f in ${files}
               do
-                  if `not_contains ${f} ${ignore_files}`; then
+                  if `contains "${ignore_files}" ${f}` || `contains ${f} ".github/"`; then
+                      echo ignore ${f}
+                  else
                       vcs import --recursive --debug < ${f}
                       ignore_files+=(${f})
                   fi

--- a/.github/workflows/ros2-build.yml
+++ b/.github/workflows/ros2-build.yml
@@ -85,7 +85,7 @@ jobs:
           do
               for f in ${files}
               do
-                  if `contains "${ignore_files}" ${f}` || `contains ${f} ".github/"`; then
+                  if `contains "${ignore_files}" ${f}` || [[ ${f} =~ ".github/" ]]; then
                       echo ignore ${f}
                   else
                       vcs import --recursive --debug < ${f}

--- a/.github/workflows/ros2-test.yml
+++ b/.github/workflows/ros2-test.yml
@@ -46,11 +46,12 @@ jobs:
               sudo apt update && sudo apt install -y python3-vcstool
           fi
 
-          not_contains() {
-              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && exit 1 || exit 0
+          contains() {
+              [[ $1 =~ (^|[[:space:]])$2($|[[:space:]]) ]] && true || false
           }
 
-          IFS=', ' read -ra ignore_files <<< "${{ inputs.ignore_rosinstalls }}"
+          ignores="${{ inputs.ignore_rosinstalls }}"
+          ignore_files=${ignores//,/ }
           files=`find . -type f -regextype posix-egrep -regex "\./.+\.rosinstall" | sort`
           pre_n=0
           n=`echo ${files} | wc -w`
@@ -58,7 +59,9 @@ jobs:
           do
               for f in ${files}
               do
-                  if `not_contains ${f} ${ignore_files}`; then
+                  if `contains "${ignore_files}" ${f}` || `contains ${f} ".github/"`; then
+                      echo ignore ${f}
+                  else
                       vcs import --recursive --debug < ${f}
                       ignore_files+=(${f})
                   fi

--- a/.github/workflows/ros2-test.yml
+++ b/.github/workflows/ros2-test.yml
@@ -59,7 +59,7 @@ jobs:
           do
               for f in ${files}
               do
-                  if `contains "${ignore_files}" ${f}` || `contains ${f} ".github/"`; then
+                  if `contains "${ignore_files}" ${f}` || [[ ${f} =~ ".github/" ]]; then
                       echo ignore ${f}
                   else
                       vcs import --recursive --debug < ${f}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

- 複数ファイル指定した場合に正しくignoreできるように
- `.github/`以下にある.rosinstallを拾わないように

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #151 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->
https://github.com/sbgisen/soar/actions/runs/4022438754/jobs/6912918743#step:7:243

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
