### PR TITLE
Add suppress-dummy-args option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ select = E,F,W,C,N,I,D,ANN
 copyright-check = True
 copyright-regexp = # Copyright \(c\) [0-9]{4} SoftBank Corp\.\n#\n# Licensed under the Apache License, Version 2\.0 \(the "License"\);\n# you may not use this file except in compliance with the License\.\n# You may obtain a copy of the License at\n#\n#     http\:\/\/www\.apache\.org\/licenses\/LICENSE-2\.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an "AS IS" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.\n# See the License for the specific language governing permissions and\n# limitations under the License\.
 docstring-convention = google
+suppress-dummy-args = True
 
 [isort]
 line_length=119


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

type hintingの際に、実際に利用しないダミーの引数（例：`rospy.Timer`用関数の引数）に関しては型指定をしなくて良いように設定。
```
./scripts/interface_controller.py:33:32: ANN001 Missing type annotation for function argument '_'
```