### PR TITLE
Add python_version input

### DIFF
--- a/.github/workflows/linter_ros_package.yaml
+++ b/.github/workflows/linter_ros_package.yaml
@@ -2,6 +2,11 @@ name: lint-ros-package
 
 on:
   workflow_call:
+    inputs:
+      python_version:
+        default: "3.8"
+        required: false
+        type: string
 
 jobs:
   changes:
@@ -89,7 +94,7 @@ jobs:
       - name: Set up Python3 environment
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: ${{ inputs.python_version }}
       - name: Download config
         run: wget https://raw.githubusercontent.com/sbgisen/.github/main/setup.cfg -O setup.cfg
       - name: autopep8 format

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ The workflow can check the following items automatically.
   - Lint (xmllint)
     - Only launch files and package.xml
 
+#### Input parameters
+
+- inputs.python_version (Optional)
+
+  Use to lint python code.
+  Default is `3.8`.
+
 #### Usage
 
 1. Create a GitHub actions workflow file in your repository. e.g. `[repository_root]/.github/workflows/[your_workflow_name].yml`


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

linterのpython versionを指定できるように

変更前
https://github.com/sbgisen/cube_python_api/actions/runs/5746683483/job/15576536788

変更後
https://github.com/sbgisen/cube_python_api/actions/runs/5747072749/job/15577508593

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #181 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
