### PR TITLE
Remove flake8-coding from requirements

### DIFF
--- a/flake8_requirements.txt
+++ b/flake8_requirements.txt
@@ -1,6 +1,5 @@
 pep8-naming
 flake8
-flake8-coding
 flake8-copyright
 flake8-annotations
 flake8-docstrings


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

#207 対応
Python3では特に必要性のない`flake8-coding`を必要なflake8の依存・ルールから外す

fix #207 

## Impact

Pythonをよく書く人は以下の点を確認しておいてください。

- 今後、Pythonスクリプトにおいていつも頭2行に書いてあるおまじないなしでもOKとする。
  - issue内で述べた通りpep8的には非推奨となっており消しても良いが、残しても害があるわけではないため、各リポジトリのメンテナに判断を任せるものとする
- 手元の環境では、`pip uninstall flake8-coding`して良い。
- 現在pre-commitを導入している人は、手動で下記画像のように`flake8-coding`を依存から外すか、本PRマージ後にcube-setup-by-ansibleのdeveloper向けセットアップを走らせ直す
![image](https://github.com/user-attachments/assets/885a15bc-f835-42b7-8c64-b8b2720c9200)

