### PR TITLE
Add ros2 style checker

### DIFF
--- a/.github/workflows/ros2-test.yml
+++ b/.github/workflows/ros2-test.yml
@@ -167,7 +167,7 @@ jobs:
       - name: Setup reviewdog
         uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
       - name: Download clang tidy config
-        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.clang-tidy -O .clang-tidy
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2/ros2/.clang-tidy -O .clang-tidy
         working-directory: ${{ github.workspace }}/ros
       - name: clang-tidy
         if: steps.changes.outputs.cpp == 'true'

--- a/.github/workflows/ros2-test.yml
+++ b/.github/workflows/ros2-test.yml
@@ -167,7 +167,8 @@ jobs:
       - name: Setup reviewdog
         uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
       - name: Download clang tidy config
-        run: wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2/ros2/.clang-tidy -O .clang-tidy
+        # yamllint disable-line rule:line-length
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/refs/heads/feature/ros2-lint/ros2/.clang-tidy -O .clang-tidy
         working-directory: ${{ github.workspace }}/ros
       - name: clang-tidy
         if: steps.changes.outputs.cpp == 'true'

--- a/.github/workflows/ros2-test.yml
+++ b/.github/workflows/ros2-test.yml
@@ -168,7 +168,7 @@ jobs:
         uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
       - name: Download clang tidy config
         # yamllint disable-line rule:line-length
-        run: wget https://raw.githubusercontent.com/sbgisen/.github/refs/heads/feature/ros2-lint/ros2/.clang-tidy -O .clang-tidy
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/refs/heads/main/ros2/.clang-tidy -O .clang-tidy
         working-directory: ${{ github.workspace }}/ros
       - name: clang-tidy
         if: steps.changes.outputs.cpp == 'true'

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -149,7 +149,10 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Download config
-        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.cmake-format -O .cmake-format
+        run: |
+          sudo apt update
+          sudo apt install -y wget
+          wget https://raw.githubusercontent.com/sbgisen/.github/main/.cmake-format -O .cmake-format
       - name: cmake-format
         run: |
           pip3 install cmake-format

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -97,7 +97,7 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
       - name: Download config
-        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/pyproject.toml -O pyproject.toml
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/pyproject.toml -O pyproject.toml
       - name: autopep8 format
         uses: peter-evans/autopep8@921e8f57f62a70ba5dd9fac0d1f4834e4d819c22 # v1.2.2
         with:
@@ -118,7 +118,7 @@ jobs:
         run: |
           pip3 install ruff
           cd ${{ github.workspace }}
-          wget https://raw.githubusercontent.com/sbgisen/.github/main/pyproject.toml -O pyproject.toml
+          wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/pyproject.toml -O pyproject.toml
           file_list="${{ needs.changes.outputs.python_files }}"
           ruff check --config /opt/work/.github/pyproject.toml |\
           reviewdog -name="ruff" -reporter=github-pr-review -efm='%f:%l:%c: %*[^0-9]%n %m' \

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -155,8 +155,7 @@ jobs:
           wget https://raw.githubusercontent.com/sbgisen/.github/main/.cmake-format -O .cmake-format
       - name: cmake-format
         run: |
-          pip3 install cmake-format
-          cd ${{ github.workspace }}
+          sudo pip3 install --break-system-packages cmake-format
           cmake-format -c .cmake-format -i ${{ needs.changes.outputs.cmake_files }}
           git diff --name-only | grep .cmake-format | xargs git checkout
       - name: suggester / cmake-format
@@ -208,7 +207,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y wget
-          cd ${{ github.workspace }}
+          ls -al
           echo ${{ needs.changes.outputs.xml_files }} |\
           xargs -n 1 | xargs -I {} bash -c "xmllint --format {} |\
           diff -B {} - |\

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -218,6 +218,6 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
           pip3 install ament-xmllint
-          ament_xmllint ${{ needs.changes.outputs.xml_files }} 1> /dev/null |\
+          ament_xmllint ${{ needs.changes.outputs.xml_files }} 2>&1 1>/dev/null |\
           reviewdog -name="xmllint" -reporter=github-pr-review -efm='%f:%l: %m' \
           -filter-mode=file -fail-level=any

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -1,0 +1,223 @@
+name: ros2_style
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        default: "3.12"
+        required: false
+        type: string
+
+jobs:
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      cpp: ${{ steps.changes.outputs.cpp }}
+      cpp_files: ${{ steps.changes.outputs.cpp_files }}
+      python: ${{ steps.changes.outputs.python }}
+      python_files: ${{ steps.changes.outputs.python_files }}
+      cmake: ${{ steps.changes.outputs.cmake }}
+      cmake_files: ${{ steps.changes.outputs.cmake_files }}
+      yaml: ${{ steps.changes.outputs.yaml }}
+      yaml_files: ${{ steps.changes.outputs.yaml_files }}
+      xml: ${{ steps.changes.outputs.xml }}
+      xml_files: ${{ steps.changes.outputs.xml_files }}
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: changed-file-filter
+        id: changes
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        with:
+          filters: |
+            cpp:
+              - added|modified: '**.h'
+              - added|modified: '**.hpp'
+              - added|modified: '**.hh'
+              - added|modified: '**.hxx'
+              - added|modified: '**.c'
+              - added|modified: '**.cpp'
+              - added|modified: '**.cc'
+              - added|modified: '**.cxx'
+            python:
+              - added|modified: '**.py'
+            cmake:
+              - added|modified: '**/CMakeLists.txt'
+              - added|modified: '**.cmake'
+            yaml:
+              - added|modified: '**.yaml'
+              - added|modified: '**.yml'
+            xml:
+              - added|modified: '**/package.xml'
+              - added|modified: '**.xacro'
+              - added|modified: '**.urdf'
+          list-files: "shell"
+
+  clang:
+    name: C++ style
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: changes
+    if: needs.changes.outputs.cpp == 'true'
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Download config
+        # yamllint disable-line rule:line-length
+        run: wget https://raw.githubusercontent.com/ament/ament_lint/refs/heads/master/ament_clang_format/ament_clang_format/configuration/.clang-format -O .clang-format
+      - uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.18.2
+        with:
+          source: ${{ needs.changes.outputs.cpp_files }}
+          exclude: ""
+          extensions: "h,hpp,hh,hxx,c,cpp,cc,cxx"
+          clangFormatVersion: 10
+          style: file
+          inplace: true
+      - name: suggester / clang-format
+        uses: reviewdog/action-suggester@8f83d27e749053b2029600995c115026a010408e # v1.6.0
+        with:
+          tool_name: clang-format
+          filter_mode: file
+          fail_on_error: true
+  python:
+    name: Python style
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Set up Python3 environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python_version }}
+      - name: Download config
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/pyproject.toml -O pyproject.toml
+      - name: autopep8 format
+        uses: peter-evans/autopep8@921e8f57f62a70ba5dd9fac0d1f4834e4d819c22 # v1.2.2
+        with:
+          args: -i --global-config pyproject.toml ${{ needs.changes.outputs.python_files }}
+      - name: Restore config
+        run: git diff --name-only | grep pyproject.toml | xargs git checkout
+      - name: suggester / autopep8
+        uses: reviewdog/action-suggester@8f83d27e749053b2029600995c115026a010408e # v1.6.0
+        with:
+          tool_name: autopep8
+          filter_mode: file
+          fail_on_error: true
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
+      - name: ruff lint
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          pip3 install ruff
+          cd ${{ github.workspace }}
+          wget https://raw.githubusercontent.com/sbgisen/.github/main/pyproject.toml -O pyproject.toml
+          file_list="${{ needs.changes.outputs.python_files }}"
+          ruff check --config /opt/work/.github/pyproject.toml |\
+          reviewdog -name="ruff" -reporter=github-pr-review -efm='%f:%l:%c: %*[^0-9]%n %m' \
+          -filter-mode=file -fail-on-error
+      - name: isort # ref #53
+        run: |
+          pip3 install isort
+          cd ${{ github.workspace }}
+          file_list="${{ needs.changes.outputs.python_files }}"
+          isort --sp pyproject.toml ${file_list}
+          git diff --name-only | grep pyproject.toml | xargs git checkout
+      - name: suggester / isort
+        uses: reviewdog/action-suggester@8f83d27e749053b2029600995c115026a010408e # v1.6.0
+        with:
+          tool_name: isort
+          filter_mode: file
+          fail_on_error: true
+
+  cmake:
+    name: CMake style
+    runs-on: ubuntu-latest
+    container:
+      image: ros:jazzy
+    timeout-minutes: 5
+    needs: changes
+    if: needs.changes.outputs.cmake == 'true'
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Download config
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.cmake-format -O .cmake-format
+      - name: cmake-format
+        run: |
+          pip3 install cmake-format
+          cmake-format -c .cmake-format -i ${{ needs.changes.outputs.cmake_files }}
+          git diff --name-only | grep .cmake-format | xargs git checkout
+      - name: suggester / cmake-format
+        uses: reviewdog/action-suggester@8f83d27e749053b2029600995c115026a010408e # v1.6.0
+        with:
+          tool_name: cmake-format
+          filter_mode: file
+          fail_on_error: true
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
+      - name: cmake-lint
+        run: |
+          sudo apt update
+          sudo apt install -y ros-jazzy-ament-lint-cmake
+          ament_cmake_lint . |\
+          reviewdog -name="cmake-lint" -reporter=github-pr-review -efm='%f:%l: %m' \
+          -filter-mode=file -fail-on-error
+
+  yamllint:
+    name: YAML style
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: changes
+    if: needs.changes.outputs.yaml == 'true'
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Download config
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.yamllint -O .yamllint
+      - name: yamllint
+        uses: reviewdog/action-yamllint@8c429dfe4fc47b1ce1fa99a64e94693880d5dc30 # v1.6.1
+        with:
+          reporter: github-pr-review
+          filter_mode: file
+          fail_on_error: true
+          yamllint_flags: -s -c .yamllint ${{ needs.changes.outputs.yaml_files }}
+  xml:
+    name: XML style
+    runs-on: ubuntu-latest
+    container:
+      image: ros:jazzy
+    timeout-minutes: 5
+    needs: changes
+    if: needs.changes.outputs.xml == 'true'
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: xml format
+        run: |
+          echo ${{ needs.changes.outputs.xml_files }} |\
+          xargs -n 1 | xargs -I {} bash -c "xmllint --format {} |\
+          diff -B {} - |\
+          patch {}"
+      - name: suggester / xmllint
+        uses: reviewdog/action-suggester@8f83d27e749053b2029600995c115026a010408e # v1.6.0
+        with:
+          tool_name: xmllint
+          filter_mode: file
+          fail_on_error: true
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
+      - name: xmllint
+        run: |
+          sudo apt update
+          sudo apt install -y ros-jazzy-ament-xmllint
+          ament_xmllint . 1> /dev/null |\
+          reviewdog -name="xmllint" -reporter=github-pr-review -efm='%f:%l: %m' \
+          -filter-mode=file -fail-on-error

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -151,7 +151,7 @@ jobs:
       - name: Download config
         run: |
           sudo apt update
-          sudo apt install -y wget
+          sudo apt install -y wget python3-pip
           wget https://raw.githubusercontent.com/sbgisen/.github/main/.cmake-format -O .cmake-format
       - name: cmake-format
         run: |

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Download config
         # yamllint disable-line rule:line-length
-        run: wget https://raw.githubusercontent.com/ament/ament_lint/refs/heads/master/ament_clang_format/ament_clang_format/configuration/.clang-format -O .clang-format
+        run: wget https://raw.githubusercontent.com/ament/ament_lint/refs/heads/rolling/ament_clang_format/ament_clang_format/configuration/.clang-format -O .clang-format
       - uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.18.2
         with:
           source: ${{ needs.changes.outputs.cpp_files }}

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -140,8 +140,6 @@ jobs:
   cmake:
     name: CMake style
     runs-on: ubuntu-latest
-    container:
-      image: ros:jazzy
     timeout-minutes: 5
     needs: changes
     if: needs.changes.outputs.cmake == 'true'
@@ -149,13 +147,10 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Download config
-        run: |
-          sudo apt update
-          sudo apt install -y wget python3-pip
-          wget https://raw.githubusercontent.com/sbgisen/.github/main/.cmake-format -O .cmake-format
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.cmake-format -O .cmake-format
       - name: cmake-format
         run: |
-          sudo pip3 install --break-system-packages cmake-format
+          pip3 install cmake-format
           cmake-format -c .cmake-format -i ${{ needs.changes.outputs.cmake_files }}
           git diff --name-only | grep .cmake-format | xargs git checkout
       - name: suggester / cmake-format
@@ -168,9 +163,8 @@ jobs:
         uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
       - name: cmake-lint
         run: |
-          sudo apt update
-          sudo apt install -y ros-jazzy-ament-lint-cmake
-          ament_cmake_lint . |\
+          pip3 install ament-lint-cmake-py
+          ament_cmake_lint ${{ needs.changes.outputs.cmake_files }} |\
           reviewdog -name="cmake-lint" -reporter=github-pr-review -efm='%f:%l: %m' \
           -filter-mode=file -fail-level=any
 
@@ -195,8 +189,6 @@ jobs:
   xml:
     name: XML style
     runs-on: ubuntu-latest
-    container:
-      image: ros:jazzy
     timeout-minutes: 5
     needs: changes
     if: needs.changes.outputs.xml == 'true'
@@ -205,9 +197,6 @@ jobs:
         uses: actions/checkout@v3
       - name: xml format
         run: |
-          sudo apt update
-          sudo apt install -y wget
-          ls -al
           echo ${{ needs.changes.outputs.xml_files }} |\
           xargs -n 1 | xargs -I {} bash -c "xmllint --format {} |\
           diff -B {} - |\
@@ -222,8 +211,7 @@ jobs:
         uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
       - name: xmllint
         run: |
-          sudo apt update
-          sudo apt install -y ros-jazzy-ament-xmllint
-          ament_xmllint . 1> /dev/null |\
+          pip3 install ament-xmllint
+          ament_xmllint ${{ needs.changes.outputs.xml_files }} 1> /dev/null |\
           reviewdog -name="xmllint" -reporter=github-pr-review -efm='%f:%l: %m' \
           -filter-mode=file -fail-level=any

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -156,6 +156,7 @@ jobs:
       - name: cmake-format
         run: |
           pip3 install cmake-format
+          cd ${{ github.workspace }}
           cmake-format -c .cmake-format -i ${{ needs.changes.outputs.cmake_files }}
           git diff --name-only | grep .cmake-format | xargs git checkout
       - name: suggester / cmake-format
@@ -207,6 +208,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y wget
+          cd ${{ github.workspace }}
           echo ${{ needs.changes.outputs.xml_files }} |\
           xargs -n 1 | xargs -I {} bash -c "xmllint --format {} |\
           diff -B {} - |\

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -162,6 +162,8 @@ jobs:
       - name: Setup reviewdog
         uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
       - name: cmake-lint
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
           pip3 install ament-lint-cmake-py
           ament_cmake_lint ${{ needs.changes.outputs.cmake_files }} |\
@@ -197,6 +199,8 @@ jobs:
         uses: actions/checkout@v3
       - name: xml format
         run: |
+          sudo apt update
+          sudo apt install libxml2-utils
           echo ${{ needs.changes.outputs.xml_files }} |\
           xargs -n 1 | xargs -I {} bash -c "xmllint --format {} |\
           diff -B {} - |\
@@ -210,6 +214,8 @@ jobs:
       - name: Setup reviewdog
         uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
       - name: xmllint
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
           pip3 install ament-xmllint
           ament_xmllint ${{ needs.changes.outputs.xml_files }} 1> /dev/null |\

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -166,7 +166,7 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
           pip3 install ament-lint-cmake-py
-          ament_cmake_lint ${{ needs.changes.outputs.cmake_files }} |\
+          ament_lint_cmake ${{ needs.changes.outputs.cmake_files }} |\
           reviewdog -name="cmake-lint" -reporter=github-pr-review -efm='%f:%l: %m' \
           -filter-mode=file -fail-level=any
 

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -205,6 +205,8 @@ jobs:
         uses: actions/checkout@v3
       - name: xml format
         run: |
+          sudo apt update
+          sudo apt install -y wget
           echo ${{ needs.changes.outputs.xml_files }} |\
           xargs -n 1 | xargs -I {} bash -c "xmllint --format {} |\
           diff -B {} - |\

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -147,7 +147,8 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Download config
-        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.cmake-format -O .cmake-format
+        # yamllint disable-line rule:line-length
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/ros2/.cmake-format -O .cmake-format
       - name: cmake-format
         run: |
           pip3 install cmake-format

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Download config
         # yamllint disable-line rule:line-length
-        run: wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/ros2/.clang-format -O .clang-format
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/ros2/.clang-format -O .clang-format
       - uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.18.2
         with:
           source: ${{ needs.changes.outputs.cpp_files }}
@@ -97,7 +97,7 @@ jobs:
         with:
           python-version: ${{ inputs.python_version }}
       - name: Download config
-        run: wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/pyproject.toml -O pyproject.toml
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/pyproject.toml -O pyproject.toml
       - name: yapf format
         run: |
           pip3 install yapf
@@ -118,7 +118,7 @@ jobs:
         run: |
           pip3 install ruff
           cd ${{ github.workspace }}
-          wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/pyproject.toml -O pyproject.toml
+          wget https://raw.githubusercontent.com/sbgisen/.github/main/pyproject.toml -O pyproject.toml
           file_list="${{ needs.changes.outputs.python_files }}"
           ruff check --config pyproject.toml |\
           reviewdog -name="ruff" -reporter=github-pr-review -efm='%f:%l:%c: %*[^0-9]%n %m' \
@@ -148,7 +148,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Download config
         # yamllint disable-line rule:line-length
-        run: wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/ros2/.cmake-format -O .cmake-format
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/main/ros2/.cmake-format -O .cmake-format
       - name: cmake-format
         run: |
           pip3 install cmake-format

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -122,7 +122,7 @@ jobs:
           file_list="${{ needs.changes.outputs.python_files }}"
           ruff check --config pyproject.toml |\
           reviewdog -name="ruff" -reporter=github-pr-review -efm='%f:%l:%c: %*[^0-9]%n %m' \
-          -filter-mode=file -fail-on-error
+          -filter-mode=file -fail-level=any
       - name: isort # ref #53
         run: |
           pip3 install isort
@@ -172,7 +172,7 @@ jobs:
           sudo apt install -y ros-jazzy-ament-lint-cmake
           ament_cmake_lint . |\
           reviewdog -name="cmake-lint" -reporter=github-pr-review -efm='%f:%l: %m' \
-          -filter-mode=file -fail-on-error
+          -filter-mode=file -fail-level=any
 
   yamllint:
     name: YAML style
@@ -225,4 +225,4 @@ jobs:
           sudo apt install -y ros-jazzy-ament-xmllint
           ament_xmllint . 1> /dev/null |\
           reviewdog -name="xmllint" -reporter=github-pr-review -efm='%f:%l: %m' \
-          -filter-mode=file -fail-on-error
+          -filter-mode=file -fail-level=any

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -98,16 +98,16 @@ jobs:
           python-version: ${{ inputs.python_version }}
       - name: Download config
         run: wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/pyproject.toml -O pyproject.toml
-      - name: autopep8 format
-        uses: peter-evans/autopep8@921e8f57f62a70ba5dd9fac0d1f4834e4d819c22 # v1.2.2
-        with:
-          args: -i --global-config pyproject.toml ${{ needs.changes.outputs.python_files }}
+      - name: yapf format
+        run: |
+          pip3 install yapf
+          yapf -ip --style pyproject.toml ${{ needs.changes.outputs.python_files }}
       - name: Restore config
         run: git diff --name-only | grep pyproject.toml | xargs git checkout
       - name: suggester / autopep8
         uses: reviewdog/action-suggester@8f83d27e749053b2029600995c115026a010408e # v1.6.0
         with:
-          tool_name: autopep8
+          tool_name: yapf
           filter_mode: file
           fail_on_error: true
       - name: Setup reviewdog

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -120,7 +120,7 @@ jobs:
           cd ${{ github.workspace }}
           wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/pyproject.toml -O pyproject.toml
           file_list="${{ needs.changes.outputs.python_files }}"
-          ruff check --config /opt/work/.github/pyproject.toml |\
+          ruff check --config pyproject.toml |\
           reviewdog -name="ruff" -reporter=github-pr-review -efm='%f:%l:%c: %*[^0-9]%n %m' \
           -filter-mode=file -fail-on-error
       - name: isort # ref #53

--- a/.github/workflows/ros2_style.yaml
+++ b/.github/workflows/ros2_style.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Download config
         # yamllint disable-line rule:line-length
-        run: wget https://raw.githubusercontent.com/ament/ament_lint/refs/heads/rolling/ament_clang_format/ament_clang_format/configuration/.clang-format -O .clang-format
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/feature/ros2-lint/ros2/.clang-format -O .clang-format
       - uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.18.2
         with:
           source: ${{ needs.changes.outputs.cpp_files }}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,50 @@ jobs:
     uses: sbgisen/.github/.github/workflows/linter_ros_package.yaml@main
 ```
 
+### Linter for ROS2 packages
+
+The workflow can check the following items automatically.
+
+- C++
+  - Format (clang-format)
+- Python
+  - Format (yapf)
+  - Lint (ruff)
+- Cmake
+  - Format (cmake-format)
+- Yaml
+  - Lint (yamllint)
+- XML (package.xml, xacro files, urdf files)
+  - Format (xmllint)
+  - Lint (xmllint)
+    - Only launch files and package.xml
+
+#### Input parameters
+
+- inputs.python_version (Optional)
+
+  Use to lint python code.
+  Default is `3.12`.
+
+#### Usage
+
+1. Create a GitHub actions workflow file in your repository. e.g. `[repository_root]/.github/workflows/[your_workflow_name].yml`
+2. Just add `uses` as in the example file.
+
+    You should set trigger to `on: [pull_request]`.
+    Because the workflow suggest format and comment lint error with Pull Request review API.
+
+```yaml
+name: [your_workflow_name]
+
+on: [pull_request]
+
+jobs:
+  linter:
+    name: Linter
+    uses: sbgisen/.github/.github/workflows/ros2_style.yaml@main
+```
+
 ### [Release Drafter](https://github.com/release-drafter/release-drafter)
 
 This repository contains Release Drafter config file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,18 @@
 [tool.isort]
 profile = "google"
-line_length = 99
+line_length = 119
 
 [tool.autopep8]
-max_line_length = 99
+max_line_length = 119
 ignore = "W503"
 aggressive = 2
 
 [tool.yapf]
 based_on_style = "google"
-column_limit = 99
+column_limit = 119
 
 [tool.ruff]
-line-length = 99
+line-length = 119
 
 [tool.ruff.lint]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,51 @@
+[tool.isort]
+profile = "google"
+line_length = 99
+
+[tool.autopep8]
+max_line_length = 99
+ignore = "W503"
+aggressive = 2
+
+[tool.yapf]
+based_on_style = "google"
+column_limit = 99
+
+[tool.ruff]
+line-length = 99
+
+[tool.ruff.lint]
+preview = true
+select = ["A", "ANN", "C4", "CPY", "D", "D401", "E", "F", "N", "Q", "W"]
+ignore = [
+    "ANN002",
+    "ANN003",
+    "ANN1",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D203",
+    "D212",
+    "D404",
+]
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-copyright]
+notice-rgx = "# Copyright \\(c\\) [0-9]{4} SoftBank Corp.\n#\n# Licensed under the Apache License, Version 2.0 \\(the \"License\"\\);\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#     http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License."
+
+[tool.ruff.lint.flake8-annotations]
+suppress-dummy-args = true
+
+[tool.ruff.format]
+quote-style = "single"
+line-ending = "lf"

--- a/ros2/.clang-format
+++ b/ros2/.clang-format
@@ -1,0 +1,20 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterEnum: true
+BreakBeforeBraces: Custom
+ColumnLimit: 120
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false
+...

--- a/ros2/.clang-tidy
+++ b/ros2/.clang-tidy
@@ -1,0 +1,49 @@
+---
+Checks: "google-*,
+  -google-explicit-constructor,
+  performance-*,
+  modernize-*
+  readability-*,
+  llvm-namespace-comment,
+  misc-unused-parameters,
+  misc-include-cleaner,
+  "
+HeaderFilterRegex: ""
+CheckOptions:
+  - key: llvm-namespace-comment.ShortNamespaceLines
+    value: "10"
+  - key: llvm-namespace-comment.SpacesBeforeComments
+    value: "2"
+  - key: misc-unused-parameters.StrictMode
+    value: "1"
+  - key: readability-braces-around-statements.ShortStatementLines
+    value: "2"
+  # type names
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.UnionCase
+    value: CamelCase
+  # method names
+  - key: readability-identifier-naming.FunctionCase
+    value: camelBack
+  # variable names
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.GlobalVariablePrefix
+    value: "g_"
+  - key: readability-identifier-naming.MemberSuffix
+    value: "_"
+  # const static or global variables are UPPER_CASE
+  - key: readability-identifier-naming.EnumConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.StaticConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.ClassConstantCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: UPPER_CASE
+  # namespace
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case

--- a/ros2/.clang-tidy
+++ b/ros2/.clang-tidy
@@ -7,6 +7,9 @@ Checks: "google-*,
   llvm-namespace-comment,
   misc-unused-parameters,
   -readability-function-cognitive-complexity,
+  -readability-magic-numbers,
+  -readability-identifier-length,
+  -performance-unnecessary-value-param,
   "
 HeaderFilterRegex: ""
 CheckOptions:

--- a/ros2/.clang-tidy
+++ b/ros2/.clang-tidy
@@ -6,7 +6,7 @@ Checks: "google-*,
   readability-*,
   llvm-namespace-comment,
   misc-unused-parameters,
-  misc-include-cleaner,
+  -readability-function-cognitive-complexity,
   "
 HeaderFilterRegex: ""
 CheckOptions:

--- a/ros2/.cmake-format
+++ b/ros2/.cmake-format
@@ -1,0 +1,250 @@
+# ----------------------------------
+# Options affecting listfile parsing
+# ----------------------------------
+with section('parse'):
+    # Specify structure for custom cmake functions
+    additional_commands = {
+        # 'find_package': {
+        #     'kwargs': {
+        #         'COMPONENTS': '*'}},
+        'add_message_files': {'kwargs': {'FILES': '*'}},
+        'add_service_files': {'kwargs': {'FILES': '*'}},
+        'add_action_files': {'kwargs': {'FILES': '*'}},
+        'generate_messages': {'kwargs': {'DEPENDENCIES': '*'}},
+        'catkin_package': {
+            'kwargs': {
+                'INCLUDE_DIRS': '*',
+                'LIBRARIES': '*',
+                'CATKIN_DEPENDS': '*',
+                'DEPENDS': '*',
+            }
+        },
+        'catkin_install_python': {'kwargs': {'PROGRAMS': '*', 'DESTINATION': '*'}},
+    }
+
+    # Override configurations per-command where available
+    override_spec = {}
+
+    # Specify variable tags.
+    vartags = []
+
+    # Specify property tags.
+    proptags = []
+
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section('format'):
+    # Disable formatting entirely, making cmake-format a no-op
+    disable = False
+
+    # How wide to allow formatted cmake files
+    line_width = 120
+
+    # How many spaces to tab for indent
+    tab_size = 2
+
+    # If true, lines are indented using tab characters (utf-8 0x09) instead of
+    # <tab_size> space characters (utf-8 0x20). In cases where the layout would
+    # require a fractional tab character, the behavior of the  fractional
+    # indentation is governed by <fractional_tab_policy>
+    use_tabchars = False
+
+    # If <use_tabchars> is True, then the value of this variable indicates how
+    # fractional indentions are handled during whitespace replacement. If set to
+    # 'use-space', fractional indentation is left as spaces (utf-8 0x20). If set
+    # to `round-up` fractional indentation is replaced with a single tab character
+    # (utf-8 0x09) effectively shifting the column to the next tabstop
+    fractional_tab_policy = 'use-space'
+
+    # If an argument group contains more than this many sub-groups (parg or kwarg
+    # groups) then force it to a vertical layout.
+    max_subgroups_hwrap = 2
+
+    # If a positional argument group contains more than this many arguments, then
+    # force it to a vertical layout.
+    max_pargs_hwrap = 2
+
+    # If a cmdline positional group consumes more than this many lines without
+    # nesting, then invalidate the layout (and nest)
+    max_rows_cmdline = 2
+
+    # If true, separate flow control names from their parentheses with a space
+    separate_ctrl_name_with_space = False
+
+    # If true, separate function names from parentheses with a space
+    separate_fn_name_with_space = False
+
+    # If a statement is wrapped to more than one line, than dangle the closing
+    # parenthesis on its own line.
+    dangle_parens = True
+
+    # If the trailing parenthesis must be 'dangled' on its on line, then align it
+    # to this reference: `prefix`: the start of the statement,  `prefix-indent`:
+    # the start of the statement, plus one indentation  level, `child`: align to
+    # the column of the arguments
+    dangle_align = 'prefix'
+
+    # If the statement spelling length (including space and parenthesis) is
+    # smaller than this amount, then force reject nested layouts.
+    min_prefix_chars = 0
+
+    # If the statement spelling length (including space and parenthesis) is larger
+    # than the tab width by more than this amount, then force reject un-nested
+    # layouts.
+    max_prefix_chars = 0
+
+    # If a candidate layout is wrapped horizontally but it exceeds this many
+    # lines, then reject the layout.
+    max_lines_hwrap = 2
+
+    # What style line endings to use in the output.
+    line_ending = 'unix'
+
+    # Format command names consistently as 'lower' or 'upper' case
+    command_case = 'canonical'
+
+    # Format keywords consistently as 'lower' or 'upper' case
+    keyword_case = 'unchanged'
+
+    # A list of command names which should always be wrapped
+    always_wrap = ['install', 'catkin_install_python']
+
+    # If true, the argument lists which are known to be sortable will be sorted
+    # lexicographicall
+    enable_sort = True
+
+    # If true, the parsers may infer whether or not an argument list is sortable
+    # (without annotation).
+    autosort = False
+
+    # By default, if cmake-format cannot successfully fit everything into the
+    # desired linewidth it will apply the last, most agressive attempt that it
+    # made. If this flag is True, however, cmake-format will print error, exit
+    # with non-zero status code, and write-out nothing
+    require_valid_layout = False
+
+    # A dictionary mapping layout nodes to a list of wrap decisions. See the
+    # documentation for more information.
+    layout_passes = {}
+
+# ------------------------------------------------
+# Options affecting comment reflow and formatting.
+# ------------------------------------------------
+with section('markup'):
+    # What character to use for bulleted lists
+    bullet_char = '*'
+
+    # What character to use as punctuation after numerals in an enumerated list
+    enum_char = '.'
+
+    # If comment markup is enabled, don't reflow the first comment block in each
+    # listfile. Use this to preserve formatting of your copyright/license
+    # statements.
+    first_comment_is_literal = False
+
+    # If comment markup is enabled, don't reflow any comment block which matches
+    # this (regex) pattern. Default is `None` (disabled).
+    literal_comment_pattern = None
+
+    # Regular expression to match preformat fences in comments default=
+    # ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+    fence_pattern = '^\\s*([`~]{3}[`~]*)(.*)$'
+
+    # Regular expression to match rulers in comments default=
+    # ``r'^\s*[^\w\s]{3}.*[^\w\s]{3}$'``
+    ruler_pattern = '^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$'
+
+    # If a comment line matches starts with this pattern then it is explicitly a
+    # trailing comment for the preceeding argument. Default is '#<'
+    explicit_trailing_pattern = '#<'
+
+    # If a comment line starts with at least this many consecutive hash
+    # characters, then don't lstrip() them off. This allows for lazy hash rulers
+    # where the first hash char is not separated by space
+    hashruler_min_length = 10
+
+    # If true, then insert a space between the first hash char and remaining hash
+    # chars in a hash ruler, and normalize its length to fill the column
+    canonicalize_hashrulers = True
+
+    # enable comment markup parsing and reflow
+    enable_markup = False
+
+# ----------------------------
+# Options affecting the linter
+# ----------------------------
+with section('lint'):
+    # a list of lint codes to disable
+    disabled_codes = []
+
+    # regular expression pattern describing valid function names
+    function_pattern = '[0-9a-z_]+'
+
+    # regular expression pattern describing valid macro names
+    macro_pattern = '[0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with global
+    # (cache) scope
+    global_var_pattern = '[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with global
+    # scope (but internal semantic)
+    internal_var_pattern = '_[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for variables with local
+    # scope
+    local_var_pattern = '[a-z][a-z0-9_]+'
+
+    # regular expression pattern describing valid names for privatedirectory
+    # variables
+    private_var_pattern = '_[0-9a-z_]+'
+
+    # regular expression pattern describing valid names for public directory
+    # variables
+    public_var_pattern = '[A-Z][0-9A-Z_]+'
+
+    # regular expression pattern describing valid names for function/macro
+    # arguments and loop variables.
+    argument_var_pattern = '[a-z][a-z0-9_]+'
+
+    # regular expression pattern describing valid names for keywords used in
+    # functions or macros
+    keyword_pattern = '[A-Z][0-9A-Z_]+'
+
+    # In the heuristic for C0201, how many conditionals to match within a loop in
+    # before considering the loop a parser.
+    max_conditionals_custom_parser = 2
+
+    # Require at least this many newlines between statements
+    min_statement_spacing = 1
+
+    # Require no more than this many newlines between statements
+    max_statement_spacing = 2
+    max_returns = 6
+    max_branches = 12
+    max_arguments = 5
+    max_localvars = 15
+    max_statements = 50
+
+# -------------------------------
+# Options affecting file encoding
+# -------------------------------
+with section('encode'):
+    # If true, emit the unicode byte-order mark (BOM) at the start of the file
+    emit_byteorder_mark = False
+
+    # Specify the encoding of the input file. Defaults to utf-8
+    input_encoding = 'utf-8'
+
+    # Specify the encoding of the output file. Defaults to utf-8. Note that cmake
+    # only claims to support utf-8 so be careful when using anything else
+    output_encoding = 'utf-8'
+
+# -------------------------------------
+# Miscellaneous configurations options.
+# -------------------------------------
+with section('misc'):
+    # A dictionary containing any per-command configuration overrides. Currently
+    # only `command_case` is supported.
+    per_command = {}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

ros2のament_lintに則りつつ、
チェック項目を拡張したROS2用のコーディングスタイルチェックを試作
今までのルールのままのほうがいいか、これでもいいかの判断用

これを守っていれば以下のものを守れる(内包している)ようにしたい
- ament_clang_format
- ament_clang-tidy
- ament_flake8
(- ament_pep257)
- ament_lint_cmake
- ament_xmllint

簡単に試した感じでは、大きく変わるところは以下の3つがありそうです。
- 1行の長さを120まで拡張していたのが100まで縮小する
- pythonのimportの順序
- pythonのdocstring周りがややうるさくなる


<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

動作確認していたPR
https://github.com/sbgisen/test_workflow/pull/6
pre-commitの導入
https://github.com/sbgisen/cube-setup-by-ansible/tree/feature/ros2-style-pre-commit
vscodeのprofile
https://github.com/sbgisen/vscode_setup/blob/feature/ros2-profile/sbgisen-ROS2.code-profile

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
