### PR TITLE
Fix clang-tidy bug

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,3 @@
+Diagnostics:
+  ClangTidy:
+    FastCheckFilter: None

--- a/.github/workflows/ros2-test.yml
+++ b/.github/workflows/ros2-test.yml
@@ -144,7 +144,7 @@ jobs:
     name: Lint after build
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: [self-hosted, docker, "${{ inputs.ros_distro }}"]
-    timeout-minutes: 10
+    timeout-minutes: 30
     needs: test
     env:
       ROS_DISTRO: "${{ inputs.ros_distro }}"
@@ -183,7 +183,7 @@ jobs:
           mv ../../build/merged_compile_commands.json ../../build/compile_commands.json
           compdb -p ../../build list > ../../compile_commands.json
           echo "------------------------ Run Clang-tidy ------------------------"
-          result=`echo ${{ steps.changes.outputs.cpp_files }} | xargs -n 1 | xargs -I {} clang-tidy --quiet {} \
+          result=`echo ${{ steps.changes.outputs.cpp_files }} | xargs -P 10 -n 1 | xargs -I {} clang-tidy --quiet {} \
           --header-filter="${{ github.workspace }}/ros/src/${{ github.event.repository.name }}/include/.*"`
           if [[ -z ${result} ]]; then
             exit 0

--- a/.github/workflows/ros2-test.yml
+++ b/.github/workflows/ros2-test.yml
@@ -175,20 +175,15 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          if [ ${{ inputs.ros_distro }} == "humble" ]; then
-            wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-            sudo add-apt-repository -y \
-            "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-16 main"
-          fi
           sudo apt-get update
-          sudo apt-get install -y clang-tidy-16
+          sudo apt-get install -y clang-tidy
           pip3 install compdb
           find ../../build -name "compile_commands.json" -exec cat {} + > ../../build/merged_compile_commands.json
           sed -i -e ':a;N;$!ba;s/\]\n*\[/,/g' ../../build/merged_compile_commands.json
           mv ../../build/merged_compile_commands.json ../../build/compile_commands.json
           compdb -p ../../build list > ../../compile_commands.json
           echo "------------------------ Run Clang-tidy ------------------------"
-          result=`echo ${{ steps.changes.outputs.cpp_files }} | xargs -n 1 | xargs -I {} clang-tidy-16 --quiet {} \
+          result=`echo ${{ steps.changes.outputs.cpp_files }} | xargs -n 1 | xargs -I {} clang-tidy --quiet {} \
           --header-filter="${{ github.workspace }}/ros/src/${{ github.event.repository.name }}/include/.*"`
           if [[ -z ${result} ]]; then
             exit 0

--- a/.github/workflows/ros2-test.yml
+++ b/.github/workflows/ros2-test.yml
@@ -170,21 +170,24 @@ jobs:
         # yamllint disable-line rule:line-length
         run: wget https://raw.githubusercontent.com/sbgisen/.github/refs/heads/main/ros2/.clang-tidy -O .clang-tidy
         working-directory: ${{ github.workspace }}/ros
+      - name: Download clangd config
+        # yamllint disable-line rule:line-length
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/refs/heads/main/.clangd -O .clangd
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
       - name: clang-tidy
         if: steps.changes.outputs.cpp == 'true'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang-tidy
-          pip3 install compdb
+          sudo apt-get install -y clangd
+          pip3 install compdb clangd-tidy
           find ../../build -name "compile_commands.json" -exec cat {} + > ../../build/merged_compile_commands.json
           sed -i -e ':a;N;$!ba;s/\]\n*\[/,/g' ../../build/merged_compile_commands.json
           mv ../../build/merged_compile_commands.json ../../build/compile_commands.json
           compdb -p ../../build list > ../../compile_commands.json
           echo "------------------------ Run Clang-tidy ------------------------"
-          result=`echo ${{ steps.changes.outputs.cpp_files }} | xargs -P 10 -n 1 | xargs -I {} clang-tidy --quiet {} \
-          --header-filter="${{ github.workspace }}/ros/src/${{ github.event.repository.name }}/include/.*"`
+          result=`clangd-tidy -p ../../ -j 10 ${{ steps.changes.outputs.cpp_files }}`
           if [[ -z ${result} ]]; then
             exit 0
           fi

--- a/ros2/.clang-tidy
+++ b/ros2/.clang-tidy
@@ -2,7 +2,7 @@
 Checks: "google-*,
   -google-explicit-constructor,
   performance-*,
-  modernize-*
+  modernize-*,
   readability-*,
   llvm-namespace-comment,
   misc-unused-parameters,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

- #236 の問題が生じており、clang-tidyをOSのデフォルトで入るバージョンに合わせることが安定につながるのでそうしました。de86e34e1b2685abfba2d604649bebf378e8b969
- clang-tidyのconfigに記法のミスがあったので修正しています。4b58d24d1075c8b3b4ad2ca6ba74252ada08341c
- `clang-tidyをOSのデフォルトで入るバージョンに合わせた` ことにより、clang-tidyの実行にものすごい時間がかかるようになってしまった、かつ、https://github.com/sbgisen/.github/issues/236#issuecomment-2581979700 にもあるようにシステムヘッダーのエラーを表示してしまうことがあったためシステムヘッダーを無視する方法を模索しましたが、どの方法も(少なくともclang-tidy 18では)うまく行きませんでした。そのため、[clangd-tidy](https://github.com/lljbash/clangd-tidy)というclangdを用いて指定したファイルのみにclang-tidyを実行するwrapperを利用するように変更し、システムヘッダーを無視と高速化の両方を達成しています。 47e516ebd6e171fdbd1a3dbb2c0fcb7eb32d26c6


<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

https://github.com/sbgisen/bounding_box_3d_estimation/actions/runs/12764435837/job/35576734928?pr=1

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
