### PR TITLE
Disable self hosted runner

### DIFF
--- a/.github/workflows/ros2-build-gpu.yml
+++ b/.github/workflows/ros2-build-gpu.yml
@@ -1,7 +1,12 @@
-name: ros-test
+name: ros2-build-gpu
 
 on:
   workflow_call:
+    secrets:
+      ssh_key:
+        required: true
+      known_hosts:
+        required: true
     inputs:
       package_name:
         default: ${{ github.event.repository.name }}
@@ -22,32 +27,48 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-test
+  group: ${{ github.workflow }}-${{ github.ref }}-build
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Run test
-    runs-on: [self-hosted, docker, "${{ inputs.ros_distro }}"]
-    env:
-      ROS_DISTRO: "${{ inputs.ros_distro }}"
+  build:
+    name: Build
+    runs-on:
+      group: gpu-large
+    container:
+      image: ros:${{ inputs.ros_distro }}
     outputs:
       upload_documents: ${{ steps.generate_documents.outputs.upload_documents }}
     steps:
+      - name: Install necessary apt packages
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-client keyboard-configuration python3-pip
+        timeout-minutes: 1
+      - name: setup ssh key
+        uses: shimataro/ssh-key-action@02d189fc92ea6279c0fea0e7a259da1b4f1d22a5 # v2.5.0
+        with:
+          key: ${{ secrets.ssh_key }}
+          known_hosts: ${{ secrets.known_hosts }}
+        timeout-minutes: 1
+      - name: Update git version
+        run: |
+          apt-get install -y software-properties-common
+          add-apt-repository -y ppa:git-core/ppa
+          apt-get update
+          apt-get install git -y
+        shell: bash
+        timeout-minutes: 3
       - name: Check out source repository
         uses: actions/checkout@v3
         with:
           path: ros/src/${{ github.event.repository.name }}
           submodules: recursive
         timeout-minutes: 1
-      - name: Upgrade apt packages
-        run: |
-          sudo apt update && sudo apt upgrade -y
-        timeout-minutes: 10
       - name: Download repositories managed by vcstool
         run: |
           if !(type vcs > /dev/null 2>&1); then
-              sudo apt update && sudo apt install -y python3-vcstool
+              apt update && apt install -y python3-vcstool git
           fi
 
           contains() {
@@ -66,7 +87,7 @@ jobs:
                   if `contains "${ignore_files}" ${f}` || [[ ${f} =~ ".github/" ]]; then
                       echo ignore ${f}
                   else
-                      vcs import --recursive --debug --force < ${f}
+                      vcs import --recursive --debug < ${f}
                       ignore_files+=(${f})
                   fi
               done
@@ -74,18 +95,22 @@ jobs:
               pre_n=${n}
               n=`echo ${files} | wc -w`
           done
-          vcs pull
         shell: bash
         working-directory: ${{ github.workspace }}/ros/src
-        timeout-minutes: 15
+        timeout-minutes: 5
       - name: Install rosdep packages
         run: |
-          echo -e "[install]\nbreak-system-packages = true" | sudo tee /etc/pip.conf > /dev/null
+          echo -e "[install]\nbreak-system-packages = true" | tee /etc/pip.conf > /dev/null
           rosdep update
           rosdep install -iry --from-paths src --rosdistro ${ROS_DISTRO}
         shell: bash
         working-directory: ${{ github.workspace }}/ros
         timeout-minutes: 15
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@c92f40bee50034e84c763e33b317c77adaa81c92 # v1.2.13
+        with:
+          max-size: 100M
+        timeout-minutes: 1
       - name: Run setup script
         run: |
           if [ "${{ inputs.setup_script }}" != "" ]; then
@@ -105,50 +130,22 @@ jobs:
           --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         shell: bash
         working-directory: ${{ github.workspace }}/ros
-        timeout-minutes: 30
+        timeout-minutes: 120
       - name: Run test
         run: |
           if [ `find src/${{ github.event.repository.name }} -name package.xml | wc -l` -eq 0 ]; then
             exit 0
           fi
           source install/setup.bash
-          colcon test --packages-up-to ${{ inputs.package_name }} --pytest-args --continue-on-collection-errors
-        shell: bash -leo pipefail {0}
+          colcon test --packages-up-to ${{ inputs.package_name }}
+        shell: bash
         working-directory: ${{ github.workspace }}/ros
-        timeout-minutes: 60
+        timeout-minutes: 30
       - name: Generate documents
         id: generate_documents
         uses: sbgisen/.github/composite/generate_sphinx_documents@main
         timeout-minutes: 10
 
-  deploy:
-    needs: test
-    timeout-minutes: 5
-    if: >-
-      needs.test.outputs.upload_documents == 1 &&
-      github.event.repository.default_branch == github.ref_name &&
-      github.event_name == 'push'
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v1
-
-  lint_after_build:
-    name: Lint after build
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: [self-hosted, docker, "${{ inputs.ros_distro }}"]
-    timeout-minutes: 30
-    needs: test
-    env:
-      ROS_DISTRO: "${{ inputs.ros_distro }}"
-    steps:
       - name: changed-file-filter
         id: changes
         uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
@@ -195,3 +192,22 @@ jobs:
           exit 1
         shell: bash
         working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
+
+  deploy:
+    needs: build
+    timeout-minutes: 5
+    if: >-
+      needs.build.outputs.upload_documents == 1 &&
+      github.event.repository.default_branch == github.ref_name &&
+      github.event_name == 'push'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/ros2-build.yml
+++ b/.github/workflows/ros2-build.yml
@@ -1,4 +1,4 @@
-name: ros2-build-from-scratch
+name: ros2-build
 
 on:
   workflow_call:
@@ -12,10 +12,6 @@ on:
         default: ${{ github.event.repository.name }}
         required: false
         type: string
-      run_test:
-        default: false
-        required: false
-        type: boolean
       runs_on:
         default: ubuntu-latest
         required: false
@@ -44,6 +40,8 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     container:
       image: ros:${{ inputs.ros_distro }}
+    outputs:
+      upload_documents: ${{ steps.generate_documents.outputs.upload_documents }}
     steps:
       - name: Install necessary apt packages
         run: |
@@ -137,7 +135,6 @@ jobs:
         working-directory: ${{ github.workspace }}/ros
         timeout-minutes: 120
       - name: Run test
-        if: inputs.run_test
         run: |
           if [ `find src/${{ github.event.repository.name }} -name package.xml | wc -l` -eq 0 ]; then
             exit 0
@@ -147,3 +144,73 @@ jobs:
         shell: bash
         working-directory: ${{ github.workspace }}/ros
         timeout-minutes: 30
+      - name: Generate documents
+        id: generate_documents
+        uses: sbgisen/.github/composite/generate_sphinx_documents@main
+        timeout-minutes: 10
+
+      - name: changed-file-filter
+        id: changes
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        with:
+          filters: |
+            cpp:
+              - added|modified: '**.h'
+              - added|modified: '**.hpp'
+              - added|modified: '**.hh'
+              - added|modified: '**.hxx'
+              - added|modified: '**.c'
+              - added|modified: '**.cpp'
+              - added|modified: '**.cc'
+              - added|modified: '**.cxx'
+          list-files: "shell"
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@8f2ec89e6b467ca9175527d2a1641bbd0c05783b # v1.0.3
+      - name: Download clang tidy config
+        # yamllint disable-line rule:line-length
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/refs/heads/main/ros2/.clang-tidy -O .clang-tidy
+        working-directory: ${{ github.workspace }}/ros
+      - name: Download clangd config
+        # yamllint disable-line rule:line-length
+        run: wget https://raw.githubusercontent.com/sbgisen/.github/refs/heads/main/.clangd -O .clangd
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
+      - name: clang-tidy
+        if: steps.changes.outputs.cpp == 'true'
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clangd
+          pip3 install compdb clangd-tidy
+          find ../../build -name "compile_commands.json" -exec cat {} + > ../../build/merged_compile_commands.json
+          sed -i -e ':a;N;$!ba;s/\]\n*\[/,/g' ../../build/merged_compile_commands.json
+          mv ../../build/merged_compile_commands.json ../../build/compile_commands.json
+          compdb -p ../../build list > ../../compile_commands.json
+          echo "------------------------ Run Clang-tidy ------------------------"
+          result=`clangd-tidy -p ../../ -j 10 ${{ steps.changes.outputs.cpp_files }}`
+          if [[ -z ${result} ]]; then
+            exit 0
+          fi
+          echo ${result}
+          exit 1
+        shell: bash
+        working-directory: ${{ github.workspace }}/ros/src/${{ github.event.repository.name }}
+
+  deploy:
+    needs: build
+    timeout-minutes: 5
+    if: >-
+      needs.build.outputs.upload_documents == 1 &&
+      github.event.repository.default_branch == github.ref_name &&
+      github.event_name == 'push'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

ros2のCIでself hosted runnerを使わないように以下を実施
- build, test, lint_after_build, deployを一つのjobでまとめて実施
- testでsimulatorを使いたい場合向けにGitHubが提供しているT4が使えるworkflowを別途用意(通常より約10倍高額なので注意)

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #192 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

- おそらくドキュメント生成で他のリポジトリで生成したインベントリの取得がうまく行かない
https://github.com/sbgisen/.github/blob/5ace3fb566e11903e0408eec9ddaf5a3c70cc4f6/composite/generate_sphinx_documents/action.yml#L44-L55
だがそもそもROS2環境でドキュメント生成のアクションが正しく動かないような気もしている

- 各種リポジトリからtestのworkflowを消す必要がある
```yaml
  test:
    needs: linter
    if: ${{ !failure() }}
    name: Test
    uses: sbgisen/.github/.github/workflows/ros2-test.yml@main
    with:
      ros_distro: jazzy
```


<!-- どのような動作検証を行ったか -->
## Test

通常のrunnerでのbuild & test
https://github.com/sbgisen/soar/actions/runs/13070505632/job/36470959981?pr=612

gpu runnerでのbuild & test
https://github.com/sbgisen/soar/actions/runs/13125463647/job/36620829937?pr=612

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
