### PR TITLE
Check private member access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ line-length = 119
 
 [tool.ruff.lint]
 preview = true
-select = ["A", "ANN", "C4", "CPY", "D", "D401", "E", "F", "N", "Q", "W"]
+select = ["A", "ANN", "C4", "CPY", "D", "D401", "E", "F", "N", "Q", "W", "SLF"]
 ignore = [
     "ANN002",
     "ANN003",


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

`._member_name` でのアクセスに対してwarningが出せるようになります。

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #251 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

pre-commitを導入していれば`._member_name` でのアクセスに対して
エラーを吐いてくれるはずです。

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
