### PR TITLE
【Noetic】Ubuntu 20.04コンテナ内でのCIテスト実行時のバグ修正

### DIFF
--- a/.github/workflows/linter_ros_package.yaml
+++ b/.github/workflows/linter_ros_package.yaml
@@ -138,10 +138,8 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          cd ${{ github.workspace }}/../
           wget https://raw.githubusercontent.com/sbgisen/.github/main/flake8_requirements.txt -O flake8_requirements.txt
           pip3 install -r flake8_requirements.txt
-          cd ${{ github.workspace }}
           wget https://raw.githubusercontent.com/sbgisen/.github/main/setup.cfg -O setup.cfg
           file_list="${{ needs.changes.outputs.python_files }}"
           flake8 --select=E,F,W,C,N,I,ANN ${file_list} |\
@@ -149,9 +147,7 @@ jobs:
           -filter-mode=file -fail-on-error
       - name: isort # ref #53
         run: |
-          cd ${{ github.workspace }}/../
           pip3 install isort
-          cd ${{ github.workspace }}
           file_list="${{ needs.changes.outputs.python_files }}"
           isort ${file_list}
           git diff --name-only | grep setup.cfg | xargs git checkout
@@ -165,9 +161,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          cd ${{ github.workspace }}/../
           pip3 install flake8-docstrings
-          cd ${{ github.workspace }}
           wget https://raw.githubusercontent.com/sbgisen/.github/main/setup.cfg -O setup.cfg
           file_list="${{ needs.changes.outputs.python_files }}"
           flake8 --select=D ${file_list} |\


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## Summary

Noetic対応のリポジトリについて、CIをUbuntu 20.04のコンテナ内で実行するようにしたことによる不具合の修正

## Detail

- 最小イメージだと未インストールであった依存パッケージの追加
- git configを修正（※）
- コンテナ環境だと不要な`cd`コマンドが移動不能なディレクトリを指定していたため、これらのコマンドを除去

（※）以下の不具合を解消
<details>

```
Run git diff --name-only | grep setup.cfg | xargs git checkout
  git diff --name-only | grep setup.cfg | xargs git checkout
  shell: sh -e {0}
  env:
    pythonLocation: /__t/Python/3.8.18/x64
    PKG_CONFIG_PATH: /__t/Python/3.8.18/x64/lib/pkgconfig
    Python_ROOT_DIR: /__t/Python/3.8.18/x64
    Python2_ROOT_DIR: /__t/Python/3.8.18/x64
    Python3_ROOT_DIR: /__t/Python/3.8.18/x64
    LD_LIBRARY_PATH: /__t/Python/3.8.18/x64/lib
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
usage: git diff --no-index [<options>] <path> <path>

Diff output format options
    -p, --patch           generate patch
    -s, --no-patch        suppress diff output
    -u                    generate patch
    -U, --unified[=<n>]   generate diffs with <n> lines context
    -W, --function-context
                          generate diffs with <n> lines context
    --raw                 generate the diff in raw format
    --patch-with-raw      synonym for '-p --raw'
    --patch-with-stat     synonym for '-p --stat'
    --numstat             machine friendly --stat
    --shortstat           output only the last line of --stat
    -X, --dirstat[=<param1,param2>...]
                          output the distribution of relative amount of changes for each sub-directory
    --cumulative          synonym for --dirstat=cumulative
    --dirstat-by-file[=<param1,param2>...]
                          synonym for --dirstat=files,param1,param2...
    --check               warn if changes introduce conflict markers or whitespace errors
    --summary             condensed summary such as creations, renames and mode changes
    --name-only           show only names of changed files
    --name-status         show only names and status of changed files
    --stat[=<width>[,<name-width>[,<count>]]]
                          generate diffstat
    --stat-width <width>  generate diffstat with a given width
    --stat-name-width <width>
                          generate diffstat with a given name width
    --stat-graph-width <width>
                          generate diffstat with a given graph width
    --stat-count <count>  generate diffstat with limited lines
    --compact-summary     generate compact summary in diffstat
    --binary              output a binary diff that can be applied
    --full-index          show full pre- and post-image object names on the "index" lines
    --color[=<when>]      show colored diff
    --ws-error-highlight <kind>
                          highlight whitespace errors in the 'context', 'old' or 'new' lines in the diff
    -z                    do not munge pathnames and use NULs as output field terminators in --raw or --numstat
    --abbrev[=<n>]        use <n> digits to display SHA-1s
    --src-prefix <prefix>
                          show the given source prefix instead of "a/"
    --dst-prefix <prefix>
                          show the given destination prefix instead of "b/"
    --line-prefix <prefix>
                          prepend an additional prefix to every line of output
    --no-prefix           do not show any source or destination prefix
    --inter-hunk-context <n>
                          show context between diff hunks up to the specified number of lines
    --output-indicator-new <char>
                          specify the character to indicate a new line instead of '+'
    --output-indicator-old <char>
                          specify the character to indicate an old line instead of '-'
    --output-indicator-context <char>
                          specify the character to indicate a context instead of ' '

Diff rename options
    -B, --break-rewrites[=<n>[/<m>]]
                          break complete rewrite changes into pairs of delete and create
    -M, --find-renames[=<n>]
                          detect renames
    -D, --irreversible-delete
                          omit the preimage for deletes
    -C, --find-copies[=<n>]
                          detect copies
    --find-copies-harder  use unmodified files as source to find copies
    --no-renames          disable rename detection
    --rename-empty        use empty blobs as rename source
    --follow              continue listing the history of a file beyond renames
    -l <n>                prevent rename/copy detection if the number of rename/copy targets exceeds given limit

Diff algorithm options
    --minimal             produce the smallest possible diff
    -w, --ignore-all-space
                          ignore whitespace when comparing lines
    -b, --ignore-space-change
                          ignore changes in amount of whitespace
    --ignore-space-at-eol
                          ignore changes in whitespace at EOL
    --ignore-cr-at-eol    ignore carrier-return at the end of line
    --ignore-blank-lines  ignore changes whose lines are all blank
    --indent-heuristic    heuristic to shift diff hunk boundaries for easy reading
    --patience            generate diff using the "patience diff" algorithm
    --histogram           generate diff using the "histogram diff" algorithm
    --diff-algorithm <algorithm>
                          choose a diff algorithm
    --anchored <text>     generate diff using the "anchored diff" algorithm
    --word-diff[=<mode>]  show word diff, using <mode> to delimit changed words
    --word-diff-regex <regex>
                          use <regex> to decide what a word is
    --color-words[=<regex>]
                          equivalent to --word-diff=color --word-diff-regex=<regex>
    --color-moved[=<mode>]
                          moved lines of code are colored differently
    --color-moved-ws <mode>
                          how white spaces are ignored in --color-moved

Other diff options
    --relative[=<prefix>]
                          when run from subdir, exclude changes outside and show relative paths
    -a, --text            treat all files as text
    -R                    swap two inputs, reverse the diff
    --exit-code           exit with 1 if there were differences, 0 otherwise
    --quiet               disable all output of the program
    --ext-diff            allow an external diff helper to be executed
    --textconv            run external text conversion filters when comparing binary files
    --ignore-submodules[=<when>]
                          ignore changes to submodules in the diff generation
    --submodule[=<format>]
                          specify how differences in submodules are shown
    --ita-invisible-in-index
                          hide 'git add -N' entries from the index
    --ita-visible-in-index
                          treat 'git add -N' entries as real in the index
    -S <string>           look for differences that change the number of occurrences of the specified string
    -G <regex>            look for differences that change the number of occurrences of the specified regex
    --pickaxe-all         show all changes in the changeset with -S or -G
    --pickaxe-regex       treat <string> in -S as extended POSIX regular expression
    -O <file>             control the order in which files appear in the output
    --find-object <object-id>
                          look for differences that change the number of occurrences of the specified object
    --diff-filter [(A|C|D|M|R|T|U|X|B)...[*]]
                          select files by diff type
    --output <file>       Output to a specific file

fatal: detected dubious ownership in repository at '/__w/fuyu_fbl_ros/fuyu_fbl_ros'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/fuyu_fbl_ros/fuyu_fbl_ros
Error: Process completed with exit code 123.
```


