### PR TITLE
【Noetic】コンテナ利用に伴い発生したエラーのまとめと修正

### DIFF
--- a/.github/workflows/linter_ros_package.yaml
+++ b/.github/workflows/linter_ros_package.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Fix Git safe directory
-        run: git config --global --add safe.directory /__w/fuyu_fbl_ros/fuyu_fbl_ros
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
       - name: Download config
         run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.clang-format -O .clang-format
       - uses: DoozyX/clang-format-lint-action@c71d0bf4e21876ebec3e5647491186f8797fde31 # v0.18.2
@@ -113,7 +113,7 @@ jobs:
         with:
           submodules: recursive
       - name: Fix Git safe directory
-        run: git config --global --add safe.directory /__w/fuyu_fbl_ros/fuyu_fbl_ros
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
       - name: Set up Python3 environment
         uses: actions/setup-python@v4
         with:
@@ -187,7 +187,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Fix Git safe directory
-        run: git config --global --add safe.directory /__w/fuyu_fbl_ros/fuyu_fbl_ros
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
       - name: Download config
         run: wget https://raw.githubusercontent.com/sbgisen/.github/main/.cmake-format -O .cmake-format
       - name: cmake-format
@@ -243,7 +243,7 @@ jobs:
       - name: Check out source repository
         uses: actions/checkout@v3
       - name: Fix Git safe directory
-        run: git config --global --add safe.directory /__w/fuyu_fbl_ros/fuyu_fbl_ros
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
       - name: Setup reviewdog
         run: |
           wget -O - -q https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh |\


### PR DESCRIPTION
## Summary

ROS1環境用のCI設定を変更した際に時間の都合上十分検証・議論せずにPRをマージしてしまったため、改めて修正が必要な箇所を修正しました。

こちらにて動作確認を実施
https://github.com/sbgisen/fuyu_fbl_ros/pull/6

## Detail

以下経緯のまとめ

- GitHub公式によりUbuntu 20.04のランナーが廃止されたので、ROS1環境のCIのおいてコンテナを導入した
- すると、後続のステップで`fatal: detected dubious ownership in repository at '/__w/repository_name/repository_name' To add an exception for this directory, call`というエラーが発生
- これは[新しいgitのバージョンでは権限周りの管理が厳しくなっており](https://github.blog/open-source/git/git-security-vulnerability-announced/)、リポジトリそのものはホスト側ランナーのrunnerユーザーが所有、CIの実行はコンテナ側のrootユーザーで実行、という 所有者の不一致が発生し、gitにブロックされているからである
- これを回避する方法としては`git config --global --add safe.directory {directory_name}`することである
- [ドキュメント](https://github.com/actions/checkout#usage)によると一歩手前の`actions/checkout@v3`のデフォルト設定には本来この設定が入っているはずである
- しかしコンテナ環境では`checkout`が行った`safe.directory`設定がコンテナ内部に引き継がれないという既知の問題があり、後続ステップでは依然として dubious ownership が発生する
  - なお、これについては明確な根拠となるドキュメントは見つからず、同様のIssueに遭遇しているのが見つかった（[参考](https://github.com/actions/checkout/issues/2031?utm_source=chatgpt.com)、[参考](https://github.com/actions/checkout/issues/2271)）
- そのため、今回は同様の問題が発生した[事例](https://github.com/actions/runner-images/issues/6775)で実施されている通り、各ジョブにて`git config --global --add safe.directory "${GITHUB_WORKSPACE}"`ステップを踏むことでこのエラーを回避する
