### PR TITLE
feat: Add auto team assign workflow for internal-employees

### DIFF
--- a/.github/workflows/auto-team-assign.yml
+++ b/.github/workflows/auto-team-assign.yml
@@ -1,0 +1,17 @@
+name: Auto assign team to new repos
+
+on:
+  repository:
+    types: [created]
+
+jobs:
+  add-team:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add internal-employees team to new repository
+        env:
+          GH_TOKEN: ${{ secrets.ORG_ADMIN_TOKEN }}
+        run: |
+          gh api -X PUT \
+            "orgs/sbgisen/teams/internal-employees/repos/sbgisen/${{ github.event.repository.name }}" \
+            -f permission="push"


### PR DESCRIPTION
## Summary
- 新規リポジトリ作成時に `internal-employees` チームを `push` 権限で自動追加するワークフローを追加
- `repository: created` イベントをトリガーに `gh api` で Team にリポジトリを追加
- Org Secret `ORG_ADMIN_TOKEN` は設定済み（visibility: selected → `.github` のみ）

## 実施済み
- `internal-employees` Team 作成済み
- 既存の全リポジトリを `push` 権限で追加済み
- `ORG_ADMIN_TOKEN` を Org Secrets に設定済み

## Test plan
- [ ] 新規テストリポジトリを作成して、`internal-employees` Team に自動追加されることを確認

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)