### PR TITLE
Use a fine-grained PAT to remove the team review request

### DIFF
--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -205,25 +205,16 @@ jobs:
               (APPROVE / COMMENT / REQUEST_CHANGES), and every finding as an entry in
               `comments[]` anchored to its file and line. Inline comments can only anchor to
               lines that are part of the diff.
-            - Those exact `gh api` commands (review submission above, request removal below)
-              are the only ones the sandbox allows. When a request fails (e.g. a comment
-              anchored outside the diff), fix it by rewriting the payload file and re-running
-              the same command, never by changing the command itself.
-            - If the review request still fails after one retry, do NOT post the findings any
-              other way (no individual comments); end the run reporting the error. The
-              workflow fails when no review has been submitted.
-            - After the review is submitted successfully, clear the pending team review
-              request (the reviewer badge): write `removal-payload.json` in the workspace
-              root containing exactly
-              {"reviewers": [], "team_reviewers": ["${{ github.event.requested_team.slug }}"]}
-              using the Write tool, then run:
-              `gh api --method DELETE repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers --input removal-payload.json`
-              This cleanup is best-effort: retry at most once and end the run normally even
-              if it fails.
+            - That exact `gh api` command is the only one the sandbox allows. When the request
+              fails (e.g. a comment anchored outside the diff), fix it by rewriting
+              `review-payload.json` and re-running the same command, never by changing the
+              command itself.
+            - If the request still fails after one retry, do NOT post the findings any other
+              way (no individual comments); end the run reporting the error. The workflow
+              fails when no review has been submitted.
             - The sandbox allows ONLY these Bash commands: `git diff`, `git log`, `git show`,
               `git blame`, `git fetch`, `gh pr view`, `gh pr diff`, and the exact review
-              submission and request removal commands above. Every other shell command is
-              rejected — do not try
+              submission command above. Every other shell command is rejected — do not try
               `cat`, `ls`, `head`, `find`, `git status`, `git branch`, `gh pr comment`,
               `gh pr review`, or any other `gh api` call (even a read-only GET). Access
               files with the Read, Grep and Glob tools instead of shell commands.
@@ -253,7 +244,7 @@ jobs:
           claude_args: |
             --model ${{ inputs.model }}
             --max-turns ${{ inputs.max_turns }}
-            --allowedTools "Read,Grep,Glob,Write,WebFetch,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git fetch:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --input review-payload.json),Bash(gh api --method DELETE repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers --input removal-payload.json)"
+            --allowedTools "Read,Grep,Glob,Write,WebFetch,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git fetch:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --input review-payload.json)"
 
       # There is deliberately no fallback posting path: when the Reviews API request does
       # not go through, the run must fail visibly instead of leaving scattered comments.

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -52,6 +52,13 @@ on:
       known_hosts:
         description: SSH known_hosts entries for the dependency repository hosts.
         required: true
+      badge_cleanup_token:
+        description: >-
+          Fine-grained PAT used to remove the team review request (the reviewer badge)
+          after the review is posted. Needs organization Members (read) and repository
+          Pull requests (write). The default GITHUB_TOKEN cannot resolve org teams and
+          would make the removal a silent no-op, so this token is required.
+        required: true
 
 permissions:
   contents: read
@@ -257,16 +264,15 @@ jobs:
             exit 1
           fi
 
-      # Best-effort cleanup: posting a review as claude[bot] does not clear the pending
-      # team review request, so remove it here. Note that GitHub sometimes ignores this
-      # removal (the API returns success but the request silently survives) — a known
-      # unresolved platform bug that hits draft PRs in particular. When that happens,
-      # remove the reviewer badge manually.
-      # See: https://github.com/orgs/community/discussions/69208
+      # Cleanup: posting a review as claude[bot] does not clear the pending team review
+      # request, so remove it here. The badge_cleanup_token PAT is used instead of the
+      # default GITHUB_TOKEN because the latter cannot resolve org teams
+      # (see https://github.com/actions/github-script/issues/284) and this DELETE
+      # silently ignores unresolvable teams while returning 200.
       - name: Remove team review request
         if: github.event.requested_team.slug != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.badge_cleanup_token }}
         run: |
           # The endpoint requires the "reviewers" field even when removing only a team.
           printf '{"reviewers": [], "team_reviewers": ["%s"]}' \

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -205,16 +205,25 @@ jobs:
               (APPROVE / COMMENT / REQUEST_CHANGES), and every finding as an entry in
               `comments[]` anchored to its file and line. Inline comments can only anchor to
               lines that are part of the diff.
-            - That exact `gh api` command is the only one the sandbox allows. When the request
-              fails (e.g. a comment anchored outside the diff), fix it by rewriting
-              `review-payload.json` and re-running the same command, never by changing the
-              command itself.
-            - If the request still fails after one retry, do NOT post the findings any other
-              way (no individual comments); end the run reporting the error. The workflow
-              fails when no review has been submitted.
+            - Those exact `gh api` commands (review submission above, request removal below)
+              are the only ones the sandbox allows. When a request fails (e.g. a comment
+              anchored outside the diff), fix it by rewriting the payload file and re-running
+              the same command, never by changing the command itself.
+            - If the review request still fails after one retry, do NOT post the findings any
+              other way (no individual comments); end the run reporting the error. The
+              workflow fails when no review has been submitted.
+            - After the review is submitted successfully, clear the pending team review
+              request (the reviewer badge): write `removal-payload.json` in the workspace
+              root containing exactly
+              {"reviewers": [], "team_reviewers": ["${{ github.event.requested_team.slug }}"]}
+              using the Write tool, then run:
+              `gh api --method DELETE repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers --input removal-payload.json`
+              This cleanup is best-effort: retry at most once and end the run normally even
+              if it fails.
             - The sandbox allows ONLY these Bash commands: `git diff`, `git log`, `git show`,
               `git blame`, `git fetch`, `gh pr view`, `gh pr diff`, and the exact review
-              submission command above. Every other shell command is rejected — do not try
+              submission and request removal commands above. Every other shell command is
+              rejected — do not try
               `cat`, `ls`, `head`, `find`, `git status`, `git branch`, `gh pr comment`,
               `gh pr review`, or any other `gh api` call (even a read-only GET). Access
               files with the Read, Grep and Glob tools instead of shell commands.
@@ -244,7 +253,7 @@ jobs:
           claude_args: |
             --model ${{ inputs.model }}
             --max-turns ${{ inputs.max_turns }}
-            --allowedTools "Read,Grep,Glob,Write,WebFetch,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git fetch:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --input review-payload.json)"
+            --allowedTools "Read,Grep,Glob,Write,WebFetch,Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git fetch:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --input review-payload.json),Bash(gh api --method DELETE repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers --input removal-payload.json)"
 
       # There is deliberately no fallback posting path: when the Reviews API request does
       # not go through, the run must fail visibly instead of leaving scattered comments.

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -184,7 +184,8 @@ jobs:
           # The OAuth token wins when both secrets are set (passing both is undefined behavior).
           anthropic_api_key: ${{ secrets.claude_code_oauth_token == '' && secrets.anthropic_api_key || '' }}
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
-          show_full_output: false
+          # Temporarily enabled to trace the in-action badge-removal experiment.
+          show_full_output: true
           # yamllint disable rule:line-length
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude_pr_review.yml
+++ b/.github/workflows/claude_pr_review.yml
@@ -184,8 +184,7 @@ jobs:
           # The OAuth token wins when both secrets are set (passing both is undefined behavior).
           anthropic_api_key: ${{ secrets.claude_code_oauth_token == '' && secrets.anthropic_api_key || '' }}
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
-          # Temporarily enabled to trace the in-action badge-removal experiment.
-          show_full_output: true
+          show_full_output: false
           # yamllint disable rule:line-length
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

レビュー後のバッジ（`sbgisen/claude` チームへのレビュー依頼）削除が一度も機能していなかった問題を修正する。

- fix #290

## Detail

- 原因: `GITHUB_TOKEN` は org チームを解決できず、DELETE は解決不能チームを黙って無視して 200 を返す（詳細 #290）
- secrets に `badge_cleanup_token`（required）を追加し、削除ステップの `GH_TOKEN` を PAT に一本化。org Secret `CLAUDE_BADGE_CLEANUP_TOKEN` 登録済み

## Impact

**破壊的変更**: caller が secret を渡さないと呼び出しが失敗する。マージ後、各 caller（現状 albion）に1行追加が必要:

```yaml
badge_cleanup_token: ${{ secrets.CLAUDE_BADGE_CLEANUP_TOKEN }}
```

## Test

- ユーザートークンで同一 DELETE を albion#172 に実行 → 即削除成功（真因検証済み）

## Attention

- PAT 有効期限 2027-08-13。失効時は再発行して Secret 差し替え