### PR TITLE
Use a concise markdown template for the PR review overview

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,18 +108,27 @@ newer feature (C++20 ranges/`std::format`, 3.12-only syntax, a newer ROS API), r
    ```markdown
    SBGISEN PR REVIEW 2026
 
+   ## EN
+
    ### Summary
-   - <what the change does — 2–4 short bullets, English, one line each>
+   - <what the change does — 2–4 short bullets, one line each>
+
+   **Verdict: <APPROVE | COMMENT | REQUEST_CHANGES>** — <one-line rationale, English>
+
+   ---
+
+   ## JP
 
    ### 概要
    - <the same bullets in Japanese>
 
-   **Verdict: <APPROVE | COMMENT | REQUEST_CHANGES>** — <one-line rationale, English / 日本語>
+   **Verdict: <APPROVE | COMMENT | REQUEST_CHANGES>** — <one-line rationale, Japanese>
    ```
 
    The first line must be exactly the marker sentence `SBGISEN PR REVIEW 2026`.
-   Verdict meanings: **APPROVE** (sound) / **COMMENT** (questions, no block) /
-   **REQUEST_CHANGES** (≥1 `[MUST-FIX]`).
+   Keep the two language blocks fully separate — never mix English and Japanese in
+   one line — and state the SAME verdict in both. Verdict meanings: **APPROVE**
+   (sound) / **COMMENT** (questions, no block) / **REQUEST_CHANGES** (≥1 `[MUST-FIX]`).
 2. **Inline comments** — one per issue, anchored to `path:line`, each starting with
    exactly one label, following the what/why/how rule, with a ```suggestion block where a
    concrete fix exists. Group duplicate instances; never flag the same issue twice.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,7 +106,7 @@ newer feature (C++20 ranges/`std::format`, 3.12-only syntax, a newer ROS API), r
    structure:
 
    ```markdown
-   # SBGISEN PR REVIEW 2026
+   ## SBGISEN PR REVIEW 2026
 
    ### Summary
    - <what the change does — 2–4 short bullets, one line each, English>
@@ -122,7 +122,7 @@ newer feature (C++20 ranges/`std::format`, 3.12-only syntax, a newer ROS API), r
    ```
 
    The first line must be the marker sentence `SBGISEN PR REVIEW 2026`, rendered as
-   the `#` heading shown above. Keep the two language blocks fully separate — never
+   the `##` heading shown above. Keep the two language blocks fully separate — never
    mix English and Japanese in one line — and state the SAME verdict in both.
    Verdict meanings: **APPROVE** (sound) / **COMMENT** (questions, no block) /
    **REQUEST_CHANGES** (≥1 `[MUST-FIX]`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,18 +106,14 @@ newer feature (C++20 ranges/`std::format`, 3.12-only syntax, a newer ROS API), r
    structure:
 
    ```markdown
-   SBGISEN PR REVIEW 2026
-
-   ## EN
+   # SBGISEN PR REVIEW 2026
 
    ### Summary
-   - <what the change does — 2–4 short bullets, one line each>
+   - <what the change does — 2–4 short bullets, one line each, English>
 
    **Verdict: <APPROVE | COMMENT | REQUEST_CHANGES>** — <one-line rationale, English>
 
    ---
-
-   ## JP
 
    ### 概要
    - <the same bullets in Japanese>
@@ -125,10 +121,11 @@ newer feature (C++20 ranges/`std::format`, 3.12-only syntax, a newer ROS API), r
    **Verdict: <APPROVE | COMMENT | REQUEST_CHANGES>** — <one-line rationale, Japanese>
    ```
 
-   The first line must be exactly the marker sentence `SBGISEN PR REVIEW 2026`.
-   Keep the two language blocks fully separate — never mix English and Japanese in
-   one line — and state the SAME verdict in both. Verdict meanings: **APPROVE**
-   (sound) / **COMMENT** (questions, no block) / **REQUEST_CHANGES** (≥1 `[MUST-FIX]`).
+   The first line must be the marker sentence `SBGISEN PR REVIEW 2026`, rendered as
+   the `#` heading shown above. Keep the two language blocks fully separate — never
+   mix English and Japanese in one line — and state the SAME verdict in both.
+   Verdict meanings: **APPROVE** (sound) / **COMMENT** (questions, no block) /
+   **REQUEST_CHANGES** (≥1 `[MUST-FIX]`).
 2. **Inline comments** — one per issue, anchored to `path:line`, each starting with
    exactly one label, following the what/why/how rule, with a ```suggestion block where a
    concrete fix exists. Group duplicate instances; never flag the same issue twice.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,10 +102,24 @@ newer feature (C++20 ranges/`std::format`, 3.12-only syntax, a newer ROS API), r
 
 ## 7. Output format
 
-1. **PR Overview** — start with this exact marker sentence: SBGISEN PR REVIEW 2026.
-   Then 2–4 sentences: what the change does and your overall judgment, ending with a
-   verdict: **APPROVE** (sound) / **COMMENT** (questions, no block) / **REQUEST_CHANGES**
-   (≥1 `[MUST-FIX]`).
+1. **PR Overview** — never prose paragraphs; use exactly this compact markdown
+   structure:
+
+   ```markdown
+   SBGISEN PR REVIEW 2026
+
+   ### Summary
+   - <what the change does — 2–4 short bullets, English, one line each>
+
+   ### 概要
+   - <the same bullets in Japanese>
+
+   **Verdict: <APPROVE | COMMENT | REQUEST_CHANGES>** — <one-line rationale, English / 日本語>
+   ```
+
+   The first line must be exactly the marker sentence `SBGISEN PR REVIEW 2026`.
+   Verdict meanings: **APPROVE** (sound) / **COMMENT** (questions, no block) /
+   **REQUEST_CHANGES** (≥1 `[MUST-FIX]`).
 2. **Inline comments** — one per issue, anchored to `path:line`, each starting with
    exactly one label, following the what/why/how rule, with a ```suggestion block where a
    concrete fix exists. Group duplicate instances; never flag the same issue twice.


### PR DESCRIPTION
## Summary

Claude PR レビューの冒頭要約（PR Overview）が英日混在の長文散文で読みづらいため、マークダウンの固定テンプレートに変更する。

- fix #293

## Detail

`copilot-instructions.md` §7 の PR Overview 規定を散文（2–4文 × 英日）から以下の固定構造に変更:

- `## SBGISEN PR REVIEW 2026`（マーカー文を H2 見出し化。文字列自体は不変のため検証用途は維持）
- `### Summary` — 英語の箇条書き 2–4個（各1行）+ `**Verdict: X** —` 英語理由1行
- `---`
- `### 概要` — 同内容の日本語箇条書き + 日本語理由1行
- 1行内での英日混在を禁止し、verdict は両ブロックで同一とする

## Impact

レビュー本文（Reviews API の `body`）の形式のみ変更。ワークフロー本体・インラインコメント形式・マーカー検証への影響なし。

## Test

albion のテスト PR（sbgisen/albion#181、`config_ref` でこのブランチを参照）で4回実行し、テンプレート準拠を確認。ターン数・コスト（31→26→24→35ターン / $1.60〜$1.89）は従来（33ターン / $1.78）と同等でコスト増なし。

出力サンプル: https://github.com/sbgisen/albion/pull/181#pullrequestreview-4936186513

## Attention

🤖 Generated with [Claude Code](https://claude.com/claude-code)